### PR TITLE
fix: multiple sboms for a root package

### DIFF
--- a/pkg/assembler/backends/ent/backend/search.go
+++ b/pkg/assembler/backends/ent/backend/search.go
@@ -484,7 +484,8 @@ func (b *EntBackend) FindDependentProduct(ctx context.Context, purl string, offs
 					})
 				})
 			}).
-			Only(ctx)
+			Order(billofmaterials.ByID(), ent.Desc()).
+			First(ctx)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
# Description of the PR

Fixes the problem when there is multiple SBOMs for a root package. The query will now get the latest SBOM as a result.

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
