### PR TITLE
Update e2e trustication test to be consistent with changes in ds1

### DIFF
--- a/demo/graphql/queries-trustification.gql
+++ b/demo/graphql/queries-trustification.gql
@@ -333,3 +333,18 @@ query FindDependentProduct {
     ...allHasSBOMTree
   }
 }
+
+query HasSBOM {
+  HasSBOM (hasSBOMSpec: {}) {
+    uri
+  }
+}
+
+query Vulnerabilities {
+  vulnerabilities(vulnSpec: {}) {
+    type
+    vulnerabilityIDs {
+      vulnerabilityID
+    }
+  }
+}

--- a/internal/testing/e2e-trustification/e2e
+++ b/internal/testing/e2e-trustification/e2e
@@ -20,7 +20,7 @@ set -euf -o pipefail
 SCRIPT_DIR=$(cd $(dirname $0); pwd)
 GUAC_DIR=$(cd ${SCRIPT_DIR}/../../..; pwd)
 
-guac_data_hash="1bc02a7b9b3eadc4bffead4ab004e78de19d2c33"
+guac_data_hash="f26c3fa0a1c1c46ac4ea21a4b17085db80bbfb46"
 
 echo @@@@ Installing gql Python package
 pip install gql[all]
@@ -77,5 +77,11 @@ diff -u "${SCRIPT_DIR}/expectFindRelatedProducts.json" "${GUAC_DIR}/gotFindRelat
 
 cat ./demo/graphql/queries-trustification.gql | gql-cli http://localhost:8080/query -o FindDependentProduct | jq 'del(.. | .id?) | del(.. | .downloadLocation?) | .findDependentProduct' > "${GUAC_DIR}/gotFindDependentProduct.json"
 diff -u "${SCRIPT_DIR}/expectFindDependentProduct.json" "${GUAC_DIR}/gotFindDependentProduct.json"
+
+cat ./demo/graphql/queries-trustification.gql | gql-cli http://localhost:8080/query -o HasSBOM | jq ' .HasSBOM |= sort ' > "${GUAC_DIR}/gotHasSBOM.json"
+diff -u "${SCRIPT_DIR}/expectHasSBOM.json" "${GUAC_DIR}/gotHasSBOM.json"
+
+cat ./demo/graphql/queries-trustification.gql | gql-cli http://localhost:8080/query -o Vulnerabilities | jq ' .vulnerabilities[].vulnerabilityIDs |= sort_by(.vulnerabilityID) ' > "${GUAC_DIR}/gotVulnerabilities.json"
+diff -u "${SCRIPT_DIR}/expectVulnerabilities.json" "${GUAC_DIR}/gotVulnerabilities.json"
 
 # Note: graphql_playground is left running, CI will clean it up

--- a/internal/testing/e2e-trustification/expectFindDependentProduct.json
+++ b/internal/testing/e2e-trustification/expectFindDependentProduct.json
@@ -5,6 +5,39 @@
       "type": "oci",
       "namespaces": [
         {
+          "namespace": "registry.redhat.io/ubi8",
+          "names": [
+            {
+              "name": "ubi8-container",
+              "versions": [
+                {
+                  "version": "sha256:269e9753043a4066af12649e921c6ad3201702fda5b2652f7a4aa010c2ed4c1a",
+                  "qualifiers": [
+                    {
+                      "key": "tag",
+                      "value": "8.8-1067"
+                    }
+                  ],
+                  "subpath": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "uri": "https://access.redhat.com/security/data/sbom/beta/spdx/ubi8-container-1e7fb966-cc2a-41e2-8e9d-ab6fb97d67d6",
+    "algorithm": "sha256",
+    "digest": "046d27ab116a37333847bc8648ce0af78d36caf719f8a8fa0a3ef2cd8d0fab89",
+    "origin": "",
+    "collector": ""
+  },
+  {
+    "subject": {
+      "__typename": "Package",
+      "type": "oci",
+      "namespaces": [
+        {
           "namespace": "registry.redhat.io/ubi8-minimal",
           "names": [
             {

--- a/internal/testing/e2e-trustification/expectHasSBOM.json
+++ b/internal/testing/e2e-trustification/expectHasSBOM.json
@@ -1,0 +1,22 @@
+{
+  "HasSBOM": [
+    {
+      "uri": "https://access.redhat.com/security/data/sbom/beta/spdx/quarkus-bom-d6ecbbd9-31bf-46fd-afda-8082120f5260"
+    },
+    {
+      "uri": "https://access.redhat.com/security/data/sbom/beta/spdx/ubi8-container-1e7fb966-cc2a-41e2-8e9d-ab6fb97d67d6"
+    },
+    {
+      "uri": "https://access.redhat.com/security/data/sbom/beta/spdx/ubi8-micro-container-0ca57f3b-b0e7-4251-b32b-d2929a52f05c"
+    },
+    {
+      "uri": "https://access.redhat.com/security/data/sbom/beta/spdx/ubi8-minimal-container-5b43ae22-cbf0-4626-8ec5-4ae0765a3d4b"
+    },
+    {
+      "uri": "https://access.redhat.com/security/data/sbom/beta/spdx/ubi9-container-f8098ef8-eee0-4ee6-b5d1-b00d992adef5"
+    },
+    {
+      "uri": "https://access.redhat.com/security/data/sbom/beta/spdx/ubi9-minimal-container-9b954617-943f-43ab-bd5b-3df62a706ed6"
+    }
+  ]
+}

--- a/internal/testing/e2e-trustification/expectVulnerabilities.json
+++ b/internal/testing/e2e-trustification/expectVulnerabilities.json
@@ -1,0 +1,93 @@
+{
+  "vulnerabilities": [
+    {
+      "type": "cve",
+      "vulnerabilityIDs": [
+        {
+          "vulnerabilityID": "cve-2023-0044"
+        },
+        {
+          "vulnerabilityID": "cve-2023-0481"
+        },
+        {
+          "vulnerabilityID": "cve-2023-0482"
+        },
+        {
+          "vulnerabilityID": "cve-2023-1108"
+        },
+        {
+          "vulnerabilityID": "cve-2023-1370"
+        },
+        {
+          "vulnerabilityID": "cve-2023-1436"
+        },
+        {
+          "vulnerabilityID": "cve-2023-1584"
+        },
+        {
+          "vulnerabilityID": "cve-2023-1664"
+        },
+        {
+          "vulnerabilityID": "cve-2023-20860"
+        },
+        {
+          "vulnerabilityID": "cve-2023-20861"
+        },
+        {
+          "vulnerabilityID": "cve-2023-20862"
+        },
+        {
+          "vulnerabilityID": "cve-2023-21971"
+        },
+        {
+          "vulnerabilityID": "cve-2023-2454"
+        },
+        {
+          "vulnerabilityID": "cve-2023-2455"
+        },
+        {
+          "vulnerabilityID": "cve-2023-24815"
+        },
+        {
+          "vulnerabilityID": "cve-2023-24998"
+        },
+        {
+          "vulnerabilityID": "cve-2023-26464"
+        },
+        {
+          "vulnerabilityID": "cve-2023-2798"
+        },
+        {
+          "vulnerabilityID": "cve-2023-28867"
+        },
+        {
+          "vulnerabilityID": "cve-2023-2974"
+        },
+        {
+          "vulnerabilityID": "cve-2023-2976"
+        },
+        {
+          "vulnerabilityID": "cve-2023-3223"
+        },
+        {
+          "vulnerabilityID": "cve-2023-33201"
+        },
+        {
+          "vulnerabilityID": "cve-2023-34453"
+        },
+        {
+          "vulnerabilityID": "cve-2023-34454"
+        },
+        {
+          "vulnerabilityID": "cve-2023-34455"
+        },
+        {
+          "vulnerabilityID": "cve-2023-44487"
+        },
+        {
+          "vulnerabilityID": "cve-2023-4853"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
# Description of the PR

Update e2e trustification test consistently with https://github.com/trustification/trustification/pull/906

Added checks for `HasSBOM` and `Vulnerabilities` resources
