### PR TITLE
Cherry-pick concurrently bulk ingestions

### DIFF
--- a/pkg/assembler/backends/ent/backend/artifact_test.go
+++ b/pkg/assembler/backends/ent/backend/artifact_test.go
@@ -18,6 +18,8 @@
 package backend
 
 import (
+	"sort"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
@@ -63,6 +65,7 @@ func (s *Suite) Test_IngestArtifacts() {
 				s.T().Errorf("demoClient.IngestArtifact() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
+			sort.Strings(got)
 			if diff := cmp.Diff(tt.want, got, ignoreID); diff != "" {
 				s.T().Errorf("Unexpected results. (-want +got):\n%s", diff)
 			}

--- a/pkg/assembler/backends/ent/backend/artifact_test.go
+++ b/pkg/assembler/backends/ent/backend/artifact_test.go
@@ -18,8 +18,6 @@
 package backend
 
 import (
-	"sort"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
@@ -65,8 +63,9 @@ func (s *Suite) Test_IngestArtifacts() {
 				s.T().Errorf("demoClient.IngestArtifact() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			sort.Strings(got)
-			if diff := cmp.Diff(tt.want, got, ignoreID); diff != "" {
+			// not the usual test but due to just returning the IDs (ignored in Diff), every check is prevented.
+			// An enhancement would be to add the query to read the three artifacts.
+			if diff := cmp.Diff(len(tt.want), len(got), ignoreID); diff != "" {
 				s.T().Errorf("Unexpected results. (-want +got):\n%s", diff)
 			}
 		})

--- a/pkg/assembler/backends/ent/backend/builders.go
+++ b/pkg/assembler/backends/ent/backend/builders.go
@@ -24,7 +24,7 @@ import (
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/predicate"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"github.com/pkg/errors"
-	"github.com/vektah/gqlparser/v2/gqlerror"
+	"golang.org/x/sync/errgroup"
 )
 
 func (b *EntBackend) Builders(ctx context.Context, builderSpec *model.BuilderSpec) ([]*model.Builder, error) {
@@ -69,15 +69,23 @@ func (b *EntBackend) IngestBuilder(ctx context.Context, build *model.BuilderInpu
 }
 
 func (b *EntBackend) IngestBuilders(ctx context.Context, builders []*model.BuilderInputSpec) ([]*model.Builder, error) {
-	var modelBuilders []*model.Builder
-	for _, builder := range builders {
-		modelBuilder, err := b.IngestBuilder(ctx, builder)
-		if err != nil {
-			return nil, gqlerror.Errorf("IngestBuilders failed with err: %v", err)
-		}
-		modelBuilders = append(modelBuilders, modelBuilder)
+	buildersID := make([]*model.Builder, len(builders))
+	eg, ctx := errgroup.WithContext(ctx)
+	for i := range builders {
+		index := i
+		bld := builders[index]
+		concurrently(eg, func() error {
+			id, err := b.IngestBuilder(ctx, bld)
+			if err == nil {
+				buildersID[index] = id
+			}
+			return err
+		})
 	}
-	return modelBuilders, nil
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+	return buildersID, nil
 }
 
 func upsertBuilder(ctx context.Context, client *ent.Tx, spec *model.BuilderInputSpec) (*ent.Builder, error) {

--- a/pkg/assembler/backends/ent/backend/certify.go
+++ b/pkg/assembler/backends/ent/backend/certify.go
@@ -24,7 +24,7 @@ import (
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/certification"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/predicate"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
-	"github.com/vektah/gqlparser/v2/gqlerror"
+	"golang.org/x/sync/errgroup"
 )
 
 type certificationInputSpec interface {
@@ -66,21 +66,29 @@ func (b *EntBackend) IngestCertifyBad(ctx context.Context, subject model.Package
 }
 
 func (b *EntBackend) IngestCertifyBads(ctx context.Context, subjects model.PackageSourceOrArtifactInputs, pkgMatchType *model.MatchFlags, certifyBads []*model.CertifyBadInputSpec) ([]*model.CertifyBad, error) {
-	var result []*model.CertifyBad
+	result := make([]*model.CertifyBad, len(certifyBads))
+	eg, ctx := errgroup.WithContext(ctx)
 	for i := range certifyBads {
+		index := i
 		var subject model.PackageSourceOrArtifactInput
 		if len(subjects.Packages) > 0 {
-			subject = model.PackageSourceOrArtifactInput{Package: subjects.Packages[i]}
+			subject = model.PackageSourceOrArtifactInput{Package: subjects.Packages[index]}
 		} else if len(subjects.Artifacts) > 0 {
-			subject = model.PackageSourceOrArtifactInput{Artifact: subjects.Artifacts[i]}
+			subject = model.PackageSourceOrArtifactInput{Artifact: subjects.Artifacts[index]}
 		} else {
-			subject = model.PackageSourceOrArtifactInput{Source: subjects.Sources[i]}
+			subject = model.PackageSourceOrArtifactInput{Source: subjects.Sources[index]}
 		}
-		cb, err := b.IngestCertifyBad(ctx, subject, pkgMatchType, *certifyBads[i])
-		if err != nil {
-			return nil, gqlerror.Errorf("IngestCertifyBads failed with err: %v", err)
-		}
-		result = append(result, cb)
+		certifyBad := *certifyBads[index]
+		concurrently(eg, func() error {
+			cb, err := b.IngestCertifyBad(ctx, subject, pkgMatchType, certifyBad)
+			if err == nil {
+				result[index] = cb
+			}
+			return err
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, err
 	}
 	return result, nil
 }
@@ -98,21 +106,29 @@ func (b *EntBackend) IngestCertifyGood(ctx context.Context, subject model.Packag
 }
 
 func (b *EntBackend) IngestCertifyGoods(ctx context.Context, subjects model.PackageSourceOrArtifactInputs, pkgMatchType *model.MatchFlags, certifyGoods []*model.CertifyGoodInputSpec) ([]*model.CertifyGood, error) {
-	var result []*model.CertifyGood
+	result := make([]*model.CertifyGood, len(certifyGoods))
+	eg, ctx := errgroup.WithContext(ctx)
 	for i := range certifyGoods {
+		index := i
 		var subject model.PackageSourceOrArtifactInput
 		if len(subjects.Packages) > 0 {
-			subject = model.PackageSourceOrArtifactInput{Package: subjects.Packages[i]}
+			subject = model.PackageSourceOrArtifactInput{Package: subjects.Packages[index]}
 		} else if len(subjects.Artifacts) > 0 {
-			subject = model.PackageSourceOrArtifactInput{Artifact: subjects.Artifacts[i]}
+			subject = model.PackageSourceOrArtifactInput{Artifact: subjects.Artifacts[index]}
 		} else {
-			subject = model.PackageSourceOrArtifactInput{Source: subjects.Sources[i]}
+			subject = model.PackageSourceOrArtifactInput{Source: subjects.Sources[index]}
 		}
-		cg, err := b.IngestCertifyGood(ctx, subject, pkgMatchType, *certifyGoods[i])
-		if err != nil {
-			return nil, gqlerror.Errorf("IngestCertifyGoods failed with err: %v", err)
-		}
-		result = append(result, cg)
+		certifyGood := *certifyGoods[index]
+		concurrently(eg, func() error {
+			cg, err := b.IngestCertifyGood(ctx, subject, pkgMatchType, certifyGood)
+			if err == nil {
+				result[index] = cg
+			}
+			return err
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, err
 	}
 	return result, nil
 }

--- a/pkg/assembler/backends/ent/backend/certifyLegal.go
+++ b/pkg/assembler/backends/ent/backend/certifyLegal.go
@@ -39,6 +39,7 @@ import (
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"github.com/pkg/errors"
 	"github.com/vektah/gqlparser/v2/gqlerror"
+	"golang.org/x/sync/errgroup"
 )
 
 func (b *EntBackend) CertifyLegal(ctx context.Context, spec *model.CertifyLegalSpec) ([]*model.CertifyLegal, error) {
@@ -69,19 +70,29 @@ func (b *EntBackend) CertifyLegal(ctx context.Context, spec *model.CertifyLegalS
 }
 
 func (b *EntBackend) IngestCertifyLegals(ctx context.Context, subjects model.PackageOrSourceInputs, declaredLicensesList [][]*model.LicenseInputSpec, discoveredLicensesList [][]*model.LicenseInputSpec, certifyLegals []*model.CertifyLegalInputSpec) ([]*model.CertifyLegal, error) {
-	var modelCertifyLegals []*model.CertifyLegal
+	modelCertifyLegals := make([]*model.CertifyLegal, len(certifyLegals))
+	eg, ctx := errgroup.WithContext(ctx)
 	for i := range certifyLegals {
+		index := i
 		var subject model.PackageOrSourceInput
 		if len(subjects.Packages) > 0 {
-			subject = model.PackageOrSourceInput{Package: subjects.Packages[i]}
+			subject = model.PackageOrSourceInput{Package: subjects.Packages[index]}
 		} else {
-			subject = model.PackageOrSourceInput{Source: subjects.Sources[i]}
+			subject = model.PackageOrSourceInput{Source: subjects.Sources[index]}
 		}
-		modelCertifyLegal, err := b.IngestCertifyLegal(ctx, subject, declaredLicensesList[i], discoveredLicensesList[i], certifyLegals[i])
-		if err != nil {
-			return nil, gqlerror.Errorf("IngestCertifyLegal failed with element #%v with err: %v", i, err)
-		}
-		modelCertifyLegals = append(modelCertifyLegals, modelCertifyLegal)
+		declaredLicense := declaredLicensesList[index]
+		discoveredLicense := discoveredLicensesList[index]
+		certifyLegal := certifyLegals[index]
+		concurrently(eg, func() error {
+			modelCertifyLegal, err := b.IngestCertifyLegal(ctx, subject, declaredLicense, discoveredLicense, certifyLegal)
+			if err == nil {
+				modelCertifyLegals[index] = modelCertifyLegal
+			}
+			return err
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, err
 	}
 	return modelCertifyLegals, nil
 }

--- a/pkg/assembler/backends/ent/backend/certifyLegal_test.go
+++ b/pkg/assembler/backends/ent/backend/certifyLegal_test.go
@@ -608,7 +608,7 @@ func (s *Suite) TestLegals() {
 			if err != nil {
 				return
 			}
-			if diff := cmp.Diff(test.ExpLegal, got, ignoreID); diff != "" {
+			if diff := cmp.Diff(test.ExpLegal, got, IngestPredicatesCmpOpts...); diff != "" {
 				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
 			}
 		})

--- a/pkg/assembler/backends/ent/backend/helpers.go
+++ b/pkg/assembler/backends/ent/backend/helpers.go
@@ -65,26 +65,3 @@ func fromPtrSlice[T any](slice []*T) []T {
 	}
 	return ptrs
 }
-
-func chunk[T any](collection []T, size int) [][]T {
-	if size <= 0 {
-		panic("Second parameter must be greater than 0")
-	}
-
-	chunksNum := len(collection) / size
-	if len(collection)%size != 0 {
-		chunksNum += 1
-	}
-
-	result := make([][]T, 0, chunksNum)
-
-	for i := 0; i < chunksNum; i++ {
-		last := (i + 1) * size
-		if last > len(collection) {
-			last = len(collection)
-		}
-		result = append(result, collection[i*size:last])
-	}
-
-	return result
-}

--- a/pkg/assembler/backends/ent/backend/helpers_test.go
+++ b/pkg/assembler/backends/ent/backend/helpers_test.go
@@ -48,10 +48,13 @@ var IngestPredicatesCmpOpts = []cmp.Option{
 	cmpopts.EquateEmpty(),
 	cmpopts.SortSlices(isDependencyLess),
 	cmpopts.SortSlices(packageLess),
+	cmpopts.SortSlices(sourceLess),
 	cmpopts.SortSlices(certifyVulnLess),
 	cmpopts.SortSlices(certifyVexLess),
 	cmpopts.SortSlices(vulnEqualLess),
 	cmpopts.SortSlices(vulnerabilityLess),
+	cmpopts.SortSlices(hasSbomLess),
+	cmpopts.SortSlices(certifyLegalLess),
 }
 
 func isDependencyLess(e1, e2 *model.IsDependency) bool {
@@ -61,6 +64,12 @@ func isDependencyLess(e1, e2 *model.IsDependency) bool {
 func packageLess(e1, e2 *model.Package) bool {
 	purl1 := helpers.PkgToPurl(e1.Type, e1.Namespaces[0].Namespace, e1.Namespaces[0].Names[0].Name, e1.Namespaces[0].Names[0].Versions[0].Version, e1.Namespaces[0].Names[0].Versions[0].Subpath, nil)
 	purl2 := helpers.PkgToPurl(e2.Type, e2.Namespaces[0].Namespace, e2.Namespaces[0].Names[0].Name, e2.Namespaces[0].Names[0].Versions[0].Version, e2.Namespaces[0].Names[0].Versions[0].Subpath, nil)
+	return purl1 < purl2
+}
+
+func sourceLess(e1, e2 *model.Source) bool {
+	purl1 := helpers.PkgToPurl(e1.Type, e1.Namespaces[0].Namespace, e1.Namespaces[0].Names[0].Name, "", "", nil)
+	purl2 := helpers.PkgToPurl(e2.Type, e2.Namespaces[0].Namespace, e2.Namespaces[0].Names[0].Name, "", "", nil)
 	return purl1 < purl2
 }
 
@@ -77,11 +86,53 @@ func vulnEqualLess(e1, e2 *model.VulnEqual) bool {
 }
 
 func vulnerabilityLess(e1, e2 *model.Vulnerability) bool {
-	if e1.Type != e2.Type {
-		return e1.Type < e2.Type
-	} else if strings.ToLower(e1.Type) == "novuln" || len(e1.Type) == 0 {
-		return false
-	} else {
-		return e1.VulnerabilityIDs[0].VulnerabilityID < e2.VulnerabilityIDs[0].VulnerabilityID
+	e1String := e1.Type
+	if len(e1.VulnerabilityIDs) > 0 {
+		e1String += e1.VulnerabilityIDs[0].VulnerabilityID
 	}
+	e2String := e1.Type
+	if len(e2.VulnerabilityIDs) > 0 {
+		e2String += e2.VulnerabilityIDs[0].VulnerabilityID
+	}
+	return e1String < e2String
+}
+
+func hasSbomLess(e1, e2 *model.HasSbom) bool {
+	switch subject1 := e1.Subject.(type) {
+	case *model.Package:
+		switch subject2 := e2.Subject.(type) {
+		case *model.Package:
+			return packageLess(subject1, subject2)
+		case *model.Artifact:
+			return false
+		}
+	case *model.Artifact:
+		switch subject2 := e2.Subject.(type) {
+		case *model.Package:
+			return true
+		case *model.Artifact:
+			return subject1.Digest < subject2.Digest
+		}
+	}
+	return false
+}
+
+func certifyLegalLess(e1, e2 *model.CertifyLegal) bool {
+	switch subject1 := e1.Subject.(type) {
+	case *model.Package:
+		switch subject2 := e2.Subject.(type) {
+		case *model.Package:
+			return packageLess(subject1, subject2)
+		case *model.Source:
+			return false
+		}
+	case *model.Source:
+		switch subject2 := e2.Subject.(type) {
+		case *model.Package:
+			return true
+		case *model.Source:
+			return sourceLess(subject1, subject2)
+		}
+	}
+	return false
 }

--- a/pkg/assembler/backends/ent/backend/occurrence.go
+++ b/pkg/assembler/backends/ent/backend/occurrence.go
@@ -28,6 +28,7 @@ import (
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 	"github.com/pkg/errors"
 	"github.com/vektah/gqlparser/v2/gqlerror"
+	"golang.org/x/sync/errgroup"
 )
 
 func (b *EntBackend) IsOccurrence(ctx context.Context, query *model.IsOccurrenceSpec) ([]*model.IsOccurrence, error) {
@@ -98,19 +99,28 @@ func (b *EntBackend) IsOccurrence(ctx context.Context, query *model.IsOccurrence
 }
 
 func (b *EntBackend) IngestOccurrences(ctx context.Context, subjects model.PackageOrSourceInputs, artifacts []*model.ArtifactInputSpec, occurrences []*model.IsOccurrenceInputSpec) ([]*model.IsOccurrence, error) {
-	var models []*model.IsOccurrence
+	models := make([]*model.IsOccurrence, len(occurrences))
+	eg, ctx := errgroup.WithContext(ctx)
 	for i := range occurrences {
+		index := i
 		var subject model.PackageOrSourceInput
 		if len(subjects.Packages) > 0 {
-			subject = model.PackageOrSourceInput{Package: subjects.Packages[i]}
+			subject = model.PackageOrSourceInput{Package: subjects.Packages[index]}
 		} else {
-			subject = model.PackageOrSourceInput{Source: subjects.Sources[i]}
+			subject = model.PackageOrSourceInput{Source: subjects.Sources[index]}
 		}
-		modelOccurrence, err := b.IngestOccurrence(ctx, subject, *artifacts[i], *occurrences[i])
-		if err != nil {
-			return nil, gqlerror.Errorf("IngestOccurrences failed with element #%v with err: %v", i, err)
-		}
-		models = append(models, modelOccurrence)
+		art := artifacts[index]
+		occ := occurrences[index]
+		concurrently(eg, func() error {
+			modelOccurrence, err := b.IngestOccurrence(ctx, subject, *art, *occ)
+			if err == nil {
+				models[index] = modelOccurrence
+			}
+			return err
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, err
 	}
 	return models, nil
 }

--- a/pkg/assembler/backends/ent/backend/source.go
+++ b/pkg/assembler/backends/ent/backend/source.go
@@ -17,6 +17,7 @@ package backend
 
 import (
 	"context"
+	stdsql "database/sql"
 	"log"
 
 	"entgo.io/ent/dialect/sql"
@@ -27,6 +28,7 @@ import (
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/sourcenamespace"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/sourcetype"
 	"github.com/guacsec/guac/pkg/assembler/graphql/model"
+	"github.com/pkg/errors"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 	"golang.org/x/sync/errgroup"
 )
@@ -231,9 +233,6 @@ func upsertSource(ctx context.Context, client *ent.Tx, src model.SourceInputSpec
 		Ignore().
 		ID(ctx)
 	if err != nil {
-<<<<<<< HEAD
-		return nil, err
-=======
 		if err != stdsql.ErrNoRows {
 			return nil, errors.Wrap(err, "upsert source name")
 		}
@@ -249,7 +248,6 @@ func upsertSource(ctx context.Context, client *ent.Tx, src model.SourceInputSpec
 		if err != nil {
 			return nil, errors.Wrap(err, "get sourcename ID")
 		}
->>>>>>> a5998883 (Ent: IngestSources optimized with concurrently (#1595))
 	}
 	log.Println(sourceNameID, src)
 


### PR DESCRIPTION
# Description of the PR

Cherry-pick of upstream commits to have more concurrently ingested bulk endpoints with Ent.

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
