### PR TITLE
feat: use separate credentials for sqs and s3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,6 @@ require (
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/arangodb/go-velocypack v0.0.0-20200318135517-5af53c29c67e // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.11 // indirect
-	github.com/aws/aws-sdk-go-v2/credentials v1.13.31 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.13.7 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.37 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.31 // indirect
@@ -208,6 +207,7 @@ require (
 	github.com/aws/aws-sdk-go v1.45.24
 	github.com/aws/aws-sdk-go-v2 v1.20.0
 	github.com/aws/aws-sdk-go-v2/config v1.18.32
+	github.com/aws/aws-sdk-go-v2/credentials v1.13.31
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.38.1
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.24.1
 	github.com/fsnotify/fsnotify v1.6.0


### PR DESCRIPTION
Credentials should be now configurable with 

S3:
```
# credentials
export SQS_ACCESS_KEY=admin
export SQS_SECRET_KEY=test123456
export SQS_REGION=us-east-1
```

SQS:
```
export S3_ACCESS_KEY=admin
export S3_SECRET_KEY=test123456
export S3_REGION=us-east-1
```

Not that besides credentials other parameters are configured as they were so far, e.g.

```
export GUAC_S3_MP=sqs
export GUAC_S3_BUCKET=bombastic
...
```

This is just a first step to deal with the blocker. We would need to rethink all the configuration of the collector and how to support both our needs and upstream community conventions.



