### PR TITLE
feat: implement tls support for internal GraphQL client

### DIFF
--- a/cmd/guacone/cmd/certify.go
+++ b/cmd/guacone/cmd/certify.go
@@ -69,7 +69,10 @@ var certifyCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		assemblerFunc := ingestor.GetAssembler(ctx, opts.graphqlEndpoint)
+		assemblerFunc, err := ingestor.GetAssembler(ctx, opts.graphqlEndpoint)
+		if err != nil {
+			logger.Fatalf("unable to create assembler: %v", err)
+		}
 
 		preds := &assembler.IngestPredicates{}
 		var pkgInput *model.PkgInputSpec


### PR DESCRIPTION
Settings like these

```
export GUAC_GQL_TLS_ROOT_CA=ca.crt
export GUAC_GQL_TLS_INSECURE=true
export GUAC_GQL_ADDR=https://localhost:8080
```

should do the trick
