### PR TITLE
tls option for prometheus metrics endpoint

### DIFF
--- a/pkg/cli/store.go
+++ b/pkg/cli/store.go
@@ -86,6 +86,10 @@ func init() {
 
 	set.Int("prometheus-addr", 9091, "port to listen to on prometheus server")
 
+
+	set.String("prometheus-tls-cert-file", "", "path to the TLS certificate in PEM format for graphql api server")
+	set.String("prometheus-tls-key-file", "", "path to the TLS key in PEM format for graphql api server")
+
 	set.StringP("interval", "i", "5m", "if polling set interval, m, h, s, etc.")
 
 	set.BoolP("cert-good", "g", false, "enable to certifyGood, otherwise defaults to certifyBad")


### PR DESCRIPTION
# Description of the PR
This allows you to provide a path to tls cert and key files to enable tls https connections for the `/metrics` endpoint
<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
