### PR TITLE
fix: properly configure gql client

### DIFF
--- a/pkg/assembler/clients/helpers/graphql.go
+++ b/pkg/assembler/clients/helpers/graphql.go
@@ -1,0 +1,37 @@
+package helpers
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/Khan/genqlient/graphql"
+	"github.com/spf13/viper"
+)
+
+func GetGqlClient(graphqlEndpoint string) (graphql.Client, error) {
+	httpClient := http.Client{}
+	certFile := viper.GetString("gql-tls-root-ca")
+	insecure := viper.GetBool("gql-tls-insecure")
+	if certFile != "" {
+		caCert, err := os.ReadFile(certFile)
+		if err != nil {
+			return nil, fmt.Errorf("unable to read root certificate: %v", err)
+		}
+		caCertPool := x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM(caCert)
+
+		httpClient = http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					RootCAs:            caCertPool,
+					InsecureSkipVerify: insecure,
+				},
+			},
+		}
+	}
+
+	return graphql.NewClient(graphqlEndpoint, &httpClient), nil
+}

--- a/pkg/ingestor/parser/csaf/parser_csaf.go
+++ b/pkg/ingestor/parser/csaf/parser_csaf.go
@@ -274,7 +274,7 @@ func generateVexIngest(ctx context.Context, c *csafParser, parser findPkgSpec, v
 
 	pkg, err := parser.findPkgSpec(ctx, product_id)
 	if err != nil {
-		logger.Warnf("[csaf] unable to locate package for not-affected product %s", product_id)
+		logger.Warnf("[csaf] unable to locate package for not-affected product %s: %v", product_id, err)
 		return nil
 	}
 	vi.Pkg = pkg


### PR DESCRIPTION
GraphQL client in Red Hat CSAF parser should be able to connect to TLS enabled graphql endpoint
