### PR TITLE
TLS for s3 collector Kafka client

### DIFF
--- a/pkg/handler/collector/s3/messaging/kafka.go
+++ b/pkg/handler/collector/s3/messaging/kafka.go
@@ -152,8 +152,8 @@ func TLSConfig(kafkaConfig viper.Viper) (*tls.Config, error) {
 	if !isTls{
 		return nil, nil
 	}
-	sslCaLocation := kafkaConfig.GetString("ssl.ca.location")
-	verifyClientCert := kafkaConfig.GetBool("enable.ssl.certificate.verification")
+	sslCaLocation := kafkaConfig.GetString("ssl-ca-location")
+	verifyClientCert := kafkaConfig.GetBool("enable-ssl-certificate-verification")
 
 	caFile, err := os.ReadFile(sslCaLocation)
 	if err != nil {

--- a/pkg/handler/collector/s3/messaging/kafka.go
+++ b/pkg/handler/collector/s3/messaging/kafka.go
@@ -80,10 +80,7 @@ func NewKafkaProvider(mpConfig MessageProviderConfig) (KafkaProvider, error) {
 	kafkaConfig.SetEnvPrefix(prefix)
 	kafkaConfig.SetEnvKeyReplacer(strings.NewReplacer("-", "__"))
 	kafkaConfig.AutomaticEnv()
-
-	protocol := kafkaConfig.GetString("security-protocol")
-
-
+	
 	mechanism, err := SASLMechanism(*kafkaConfig)
 	if err != nil {
 		return KafkaProvider{}, err


### PR DESCRIPTION
# Description of the PR

This adds  'SASL_SSL' and 'SSL' security protocols and associated TLS Config setup in the kafka Dialer

you can use environment variables like this

```
export TCK_SECURITY__PROTOCOL=SASL_SSL
or
export TCK_SECURITY__PROTOCOL=SSL

export TCK_ENABLE__SSL__CERTIFICATE__VERIFICATION=false
export TCK_SSL__CA__LOCATION=/etc/ssl/certs/ca-certificates.crt
```

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
