### PR TITLE
upgrade golang to fix a cve vulnerability

### DIFF
--- a/dockerfiles/Dockerfile.guac-ubi
+++ b/dockerfiles/Dockerfile.guac-ubi
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi9/ubi:latest as builder
 
-RUN curl -L -o golang.tar.gz https://go.dev/dl/go1.21.7.linux-amd64.tar.gz && tar xvf golang.tar.gz && mv go /usr/local
+RUN curl -L -o golang.tar.gz https://go.dev/dl/go1.21.10.linux-amd64.tar.gz && tar xvf golang.tar.gz && mv go /usr/local
 RUN dnf install -y jq https://github.com/goreleaser/goreleaser/releases/download/v1.21.2/goreleaser-1.21.2-1.x86_64.rpm
 RUN dnf install -y make
 ADD . /go/src/github.com/guacsec/guac/


### PR DESCRIPTION
# Description of the PR
upgrade of golang version used in builds to fix a cve vulnerability

https://issues.redhat.com/browse/TC-1178
https://bugzilla.redhat.com/show_bug.cgi?id=2268273

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
