### PR TITLE
TC-1609 Improve package's qualifiers management

### DIFF
--- a/demo/graphql/queries-trustification.gql
+++ b/demo/graphql/queries-trustification.gql
@@ -366,3 +366,17 @@ query TC_1593_HasMetadata {
     }
   }
 }
+
+query TC_1609_HasMetadata {
+  HasMetadata (hasMetadataSpec: {
+    key: "topLevelPackage",
+    value: "pkg:maven/com.example/demo@0.0.1-SNAPSHOT?type=jar",
+    subject: {package: {name:"org-crac"}}
+  }) {
+    subject {
+      ... on Package {
+        ...allPkgTree
+      }
+    }
+  }
+}

--- a/internal/testing/e2e-trustification/e2e
+++ b/internal/testing/e2e-trustification/e2e
@@ -95,5 +95,13 @@ diff -u "${SCRIPT_DIR}/expectTC_1593_HasMetadata.json" "${GUAC_DIR}/gotTC_1593_H
 cat "$queries" | gql-cli http://localhost:8080/query -o TC_1593_FindDependentProduct | jq 'del(.. | .id?) | del(.. | .downloadLocation?) | .findDependentProduct' > "${GUAC_DIR}/gotTC_1593_FindDependentProduct.json"
 diff -u "${SCRIPT_DIR}/expectTC_1593_FindDependentProduct.json" "${GUAC_DIR}/gotTC_1593_FindDependentProduct.json"
 
+# IMPORTANT: this must happen after the above 'ds1/sbom' has been executed to reproduce the issue
+echo @@@@ Ingesting TC_1609_sbom.json into server
+time go run ./cmd/guacone collect files ${GUAC_DIR}/internal/testing/testdata/exampledata/TC_1609_sbom.json;
+
+echo @@@@ Running TC_1609 queries and validating output
+
+cat "$queries" | gql-cli http://localhost:8080/query -o TC_1609_HasMetadata | jq 'del(.. | .id?) | .HasMetadata | sort ' > "${GUAC_DIR}/gotTC_1609_HasMetadata.json"
+diff -u "${SCRIPT_DIR}/expectTC_1609_HasMetadata.json" "${GUAC_DIR}/gotTC_1609_HasMetadata.json"
 
 # Note: graphql_playground is left running, CI will clean it up

--- a/internal/testing/e2e-trustification/expectTC_1609_HasMetadata.json
+++ b/internal/testing/e2e-trustification/expectTC_1609_HasMetadata.json
@@ -1,0 +1,29 @@
+[
+  {
+    "subject": {
+      "type": "maven",
+      "namespaces": [
+        {
+          "namespace": "io.github.crac",
+          "names": [
+            {
+              "name": "org-crac",
+              "versions": [
+                {
+                  "version": "0.1.1.redhat-00002",
+                  "qualifiers": [
+                    {
+                      "key": "type",
+                      "value": "jar"
+                    }
+                  ],
+                  "subpath": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+]

--- a/internal/testing/testdata/exampledata/TC_1609_sbom.json
+++ b/internal/testing/testdata/exampledata/TC_1609_sbom.json
@@ -1,0 +1,18067 @@
+{
+  "bomFormat" : "CycloneDX",
+  "specVersion" : "1.4",
+  "serialNumber" : "urn:uuid:4dd9ce9a-b3f2-47c9-b670-a7884f29fd21",
+  "version" : 1,
+  "metadata" : {
+    "timestamp" : "2024-06-28T10:21:35Z",
+    "tools" : [
+      {
+        "vendor" : "OWASP Foundation",
+        "name" : "CycloneDX Maven plugin",
+        "version" : "2.7.7",
+        "hashes" : [
+          {
+            "alg" : "MD5",
+            "content" : "436dfb24c63a322708e4a5143d8543af"
+          },
+          {
+            "alg" : "SHA-1",
+            "content" : "3ef2e8728dc9eff2f129c34057e46e9d2b10629a"
+          },
+          {
+            "alg" : "SHA-256",
+            "content" : "c185b79bf0f9264f43bc8c222c44db67bea275bb727e3327cf9aea6bf45292c9"
+          },
+          {
+            "alg" : "SHA-512",
+            "content" : "41488733e31e6c5315327dcc86187c2b9a6b96cd08f7e2157ce130688afde29c313fc6a73edb8a76333a930c78874aa2eac874448920030c0f7af0ac05e65ced"
+          },
+          {
+            "alg" : "SHA-384",
+            "content" : "f9462f86240fd9fc0942f34981e6d2371f252aa1a4e5e8c3c14e7f0f1a4e4de69ef972e51cf09a749afb6d97c13e67ed"
+          },
+          {
+            "alg" : "SHA3-384",
+            "content" : "c755af6239348bc7dd1e1e6b5f14f7cf7e1560d689b252d9610cd865fa4b419d0b8e26260731dfc5da2176b6e706b414"
+          },
+          {
+            "alg" : "SHA3-256",
+            "content" : "309aac91005470c9c834354ab918759e2ae7ec52fc1676002621a5bbdf3b7827"
+          },
+          {
+            "alg" : "SHA3-512",
+            "content" : "c634570dcf8302e61005e5fa91a9a0d9b81542f731967b3c9f6d3ef89e3b945bd36d7ab69e2ebad8124b9c05da504361c8b36a8ce528d844409eeb7df4eea6ce"
+          }
+        ]
+      }
+    ],
+    "component" : {
+      "group" : "com.example",
+      "name" : "demotest",
+      "version" : "0.0.1-SNAPSHOT",
+      "description" : "Demo project for Spring Boot",
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.example/demo@0.0.1-SNAPSHOT?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot/demo"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot/demo"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.example/demo@0.0.1-SNAPSHOT?type=jar"
+    },
+    "properties" : [
+      {
+        "name" : "maven.goal",
+        "value" : "makeAggregateBom"
+      },
+      {
+        "name" : "maven.scopes",
+        "value" : "compile,provided,runtime,system"
+      }
+    ]
+  },
+  "components" : [
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-resteasy",
+      "version" : "2.13.7.Final",
+      "description" : "REST endpoint framework implementing JAX-RS and more",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "969d0d22ee065be1e6f18b69f4417ff9"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "20229877f4159b49c3f614061e26971d1eb30c9d"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "b034e40db8bd4d908a93b29113920b2c19b58f95e67b34b1f3c80979466da97a"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "9fb36facd867667bfdc4f11133491b03bfb3eca5f792724e472054013db547f69421b84a1e93a211f7270746af38c29c16eb4a8f9f345710fd181e61d73289d6"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "f59398d67c25cc932ed83d687708f0c30d5bd9e8c9ad6c91ff9432fbec8295f70b949cddba51365e91f2c97e1dbfad6d"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "588a882643a20d53b57ff94758c5e09e851871790e6b9c9db480c4956448eeee949da0cb61a8ed71207fcf16766d53b9"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "9a6a4f20d7c8f96b8b81514d0b34de34af414f0b4eaf45894026254e4ee8058f"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "32007ca5e233dd0ffea8bc2afe5ed1f731897496d6d1bcfca90caab821bcd334b228c0dbdcac3696d4a4abc0562b88ce0372a9814123a3370aa4935bf4d92b05"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-resteasy@2.13.7.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-resteasy@2.13.7.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-resteasy-server-common",
+      "version" : "2.13.7.Final",
+      "description" : "RESTEasy Server common",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "08aeb9e6c563e1e65727780fc2a6b693"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "34bac166057cd9f80614968cb52c85f33de5e3ee"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "fe0fd502804025ea768f0fa3700e6efff4aabac6d1051b2d410d3960dae116f9"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "12d41944bcc85a551b7e4298b011ff3657d918eb25e6bf32f9f3113f5fe2606e078e14ddadca70677e5357e2ef789db0ecacfb37d5e6641ddf381e2f2db46d2f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "0f2bcc3787f05dd24a2d14a604532349b905c8de8ea62adffe5de251f68e3d2d09c6702955ac75c9dd2feb11d69e5afa"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "6f1279e8aca812c1cb467b46c03fcfdabc27f4ca371a363e4d73fd7a1d7dc949bc67ca3c00c04318fb92093839fd7641"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "dcdc832061f0e6ad88df5a7467f95a8558f1e14eafbd240724a596a297f087e6"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "9c2d9efc0f6c655d0741a2ddb0c80204913742303f3192a1841f5348e61ceb2a851db6de48810e66359858bb7bd21e93881f3700490e3ea747a4e21a304c775f"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-resteasy-server-common@2.13.7.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-resteasy-server-common@2.13.7.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-resteasy-common",
+      "version" : "2.13.7.Final",
+      "description" : "Components common to the RESTEasy server and the REST Client",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e19003535255b7ea057dfa7e0fd04e78"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "eee47b320599f6c762ed31960cdd04c15f0cbaf4"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "e82b76e4f503f4da6c2f9496fbdd58528a155118a75de52a314dc4274274647f"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "ce5eda2d3f3a96edcbca144a3e9f34678d7f35a4641fd2aa18c0bd693328164143047aea4dbbe54c30cb975dd70330963a3db9723409f2158d8267960edbc2af"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "53137e5587f301be60b8206ac4ff41bce499a54fc140e99a8545be5dd8049c9f3769b0607d385561feb150f5e90c8806"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "3cbe93cf126a523b406bacaa9d2a2f476e67b1124725b4e79107e161b0aaca8205beac60695eef131440dacc47483f27"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "dfe64537072abc8d1c8709cc48cd45fbbde8a37dccfd237bc7ea4afd321b0b92"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "ad9afed89c6e737bb97b639b070034203945bcfd86353bad1bb7ccfbc686eb920ef25745baea748d151dde667a0ca51fb507fcf4cef25b231368c82b761b6e88"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-resteasy-common@2.13.7.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-resteasy-common@2.13.7.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "org.jboss.resteasy",
+      "name" : "resteasy-core",
+      "version" : "4.7.7.Final",
+      "description" : "",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "8b4d5995e9cb514a2042e58c8875af3a"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "f1c7e77f5c011e642695e2b8afbbdf8c9cf3c145"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "e08af827abfae5157dc1121b9347bea3d9bff7648a30c6dac885b9425ca54c6f"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "b36b5ea5126bd76b66d5d86edee3521f32ac8a0761a395f12a067ea9515d1f5bc96db66db6275bc70fef643b1a83fa6e5717a5d9481f41cdb06aa054670810d2"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "368c44e502c6631df5936892fa3052995d124f19eaa5e14d9d6b0a5a6383081839c03819cbb715f93b701a580de763fb"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "8e7fb3d3e30462af49284cef011e1a6f4b47e7c74bcf9586db8682cbc246e46cb9d1ccc3cee5211908372744acbd4ec7"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "0c13e04c77b2404a0f9727981b2da0345fd840ea9da05857ec4f0f734ce70611"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "7c19dd33a91c28c3b23205e8c2f65fe52263b58b77769ca6764370a9ae6ec8760d5db14eb646f2a205ce919a08e3675c6fe17ca600d67f19caaab2d58530b963"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.jboss.resteasy/resteasy-core@4.7.7.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://jboss.org/resteasy/resteasy-core"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.redhat.com/browse/RESTEASY"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/resteasy/Resteasy/tree/master/resteasy-core/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.jboss.resteasy/resteasy-core@4.7.7.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "org.jboss.spec.javax.annotation",
+      "name" : "jboss-annotations-api_1.3_spec",
+      "version" : "2.0.1.Final",
+      "description" : "JBoss Jakarta Annotations API",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e749fa3db958f32ca811bce62039facb"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "b3744f492ce9a65d1197a5b24645dff93fa85424"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "afc4e3b8701119c9a2ceb8cebe3fd1869a269de768d7d56e7b5051827a132368"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "676a634cab53b730e48d2b4cf53d60f8d3cbf930241f97f2810e31dc7f76e9a18b093078d72c9c7b444bc8ed0904c706a72c6be815e7fb90da35db2c7d6df284"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "a62d2d47a12907d2815c610258841f157a9cae47b4f73d6177aae62faeeefce83f6040ad16ccb1b85b6582ad9c018529"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "606d632a3e4be3e5ac390c59224283ae07db8011424db98f0144cc5da00d842c61b905edd914d5d11cc77bb3fea4e3f0"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "58a3554542f4e28164fabf87096c5dbcd389d7e4b573b2f7d70768fc57ac843d"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "fa5fc6ab388ad66e2949998ac19fe4554bfc73b7d8e9224a0374b9da3bef5cf4c200d56794740c5d9d98e2082cab7398d3d6b85ab4c815df8865ca9b308cdb84"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "GPL-2.0-with-classpath-exception"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.jboss.spec.javax.annotation/jboss-annotations-api_1.3_spec@2.0.1.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/jboss/jboss-jakarta-annotations-api_spec"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/common-annotations-api/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/jboss/jboss-jakarta-annotations-api_spec.git"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.jboss.spec.javax.annotation/jboss-annotations-api_1.3_spec@2.0.1.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "org.jboss.resteasy",
+      "name" : "resteasy-core-spi",
+      "version" : "4.7.7.Final",
+      "description" : "",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "b1aa0875245b6b0fd7ec4b7cc462dad3"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "3773ff45723fe7365bf23e846f0d7a746c7f251d"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "82e18ede12314c8a6e9fb0ef0e49a855b2e8fb01c56f8d86f1e6ce1261b2bda7"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "a0e2c6c2ea59e8cefd3e20692bad10ced3bb6545a14b185a03fae56f12e35fb098b7383dd7dba23b9fe03d7ed4c82d9056df2bb930b86dacb051bd58af052d8c"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "f8f68ad131ce3d208ecddae1e0bb240ff70ad943c3e2ccff768d35681af417c694aa0aeaa270d4bcebbf214a41676184"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "62c9c2291d3e0685c633203826f9aa211863b19b1ed1d24329f1224299989deb91a05f609639aba2959c756c2d3d39cb"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "d9b3430d5d1162933a2437c1aac3b8883ebec79f93b37ba0261f55843914cd2d"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "3fd96084950d7cf41445f2809c02d54f5488717fdbd7e959a936044fcc9a2421df7e3ed1a397e16fb36737c11c031ae951fb8127bcf72315bcd11ddf047e0551"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.jboss.resteasy/resteasy-core-spi@4.7.7.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://jboss.org/resteasy/resteasy-core-spi"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.redhat.com/browse/RESTEASY"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/resteasy/Resteasy/tree/master/resteasy-core-spi/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.jboss.resteasy/resteasy-core-spi@4.7.7.Final?type=jar"
+    },
+    {
+      "group" : "org.reactivestreams",
+      "name" : "reactive-streams",
+      "version" : "1.0.3",
+      "description" : "A Protocol for Asynchronous Non-Blocking Data Sequence",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "69122b098fff1c6b1bf2cd3b355e7e03"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "d9fb7a7926ffa635b3dcaa5049fb2bfa25b3e7d0"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "1dee0481072d19c929b623e155e14d2f6085dc011529a0a0dbefc84cf571d865"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "aafc86186d82b4f3bd44ef7f955978481172eab267d208aa80b24f8ca218bd902d69b587fcae2fe44a888b7a9f81fc5a209e837958307fdc0ee815248f7065f9"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "dde10163531896f3b60261795a977cea1d0114514e8fc95f1ac4b6f34789c4b78c4c83ead210901a2edb3cae9f113ed4"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "4f9e101774f39c8ebcb2ccd3f2fe996a1f99bd879fa34ac9ba319e824752f6bdc6159d242497d38587d7191bba796e3a"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "45c5459f651963c5797e32c87e3b8456238229f9f9e64f543eb21d6a6b7a812e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "9edc79ccfd2edabe1339ad79a10137cd0f1614671f976d6a8a603428b8e5179c9a6afbf4f9fcd44e6e3795be5c487cc5aa97a1d3e6d9a3e88a62d3f4de60a2ab"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "CC0-1.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.reactivestreams/reactive-streams@1.0.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.reactive-streams.org/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.reactivestreams/reactive-streams@1.0.3?type=jar"
+    },
+    {
+      "group" : "com.ibm.async",
+      "name" : "asyncutil",
+      "version" : "0.1.0",
+      "description" : "Utilities for working with CompletionStages",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "cbf288497b12b8c6c4ca728c57db77fd"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "440941c382166029a299602e6c9ff5abde1b5143"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "cb80a7a5cd1fef63c7ea4c9abbc5138e84136657c19d148879d22e28e144fe04"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "ecad12fbf06fb6713a5ef45bf7ba9b92c3ccb807c755360ecaa19a2bebb1156b335af407712ddfbe197143db8de6b03797c09eeb06aff7957b8d01e94bf23763"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "2d8fd4ed2a0d598877cd5f6ac41a1f925f084a96a03271f8e4df282a3f6f449fe8571129a60833740a324df50420414c"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "7c108ebea7f278658414d7a4dc497b891a4647ee79ef873c58befbfbbee1d1bacef1d96006d736e3c1fa84a7ef264b20"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "469a2b3c3cd89608dd04c1a3113dce745a7a65e21d88f3b5460704622a8af71c"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "e48405b1ffa013f2d5847e9f9d77b03eff534488224717d09c02eab016b1c74721d1414c8a7648ac135213dcc2b32df056d75300f16c4f9519b9da94cb960417"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.ibm.async/asyncutil@0.1.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://github.com/ibm/java-async-util"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/ibm/java-async-util"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.ibm.async/asyncutil@0.1.0?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "jakarta.validation",
+      "name" : "jakarta.validation-api",
+      "version" : "2.0.2",
+      "description" : "Jakarta Bean Validation API",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "77501d529c1928c9bac2500cc9f93fb0"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "5eacc6522521f7eacb081f95cee1e231648461e7"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "b42d42428f3d922c892a909fa043287d577c0c5b165ad9b7d568cebf87fc9ea4"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "3ca8556b80ca809b3a43fac31469702bbad62a00e63b11a304dad1e372d9f6c128357463a4c70c423055941c7e2e417f87a9474a204d189c8e4b62f42047c8eb"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "6ae3963fd6a5e83b068a8344b88f6bfbd26d29cee64193025bc5e98195678e49826463da27a7a1c15cd83b2149d57a94"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "55a570386718064b422f9ebc0c0c07f0b37259e44a14c9a16c20e945402339b1d01b7d6969ef40d6b5baf5bce3e1161d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "1ff48fdabab86a398b25e491e6ba4fd9b62d597314202628a3cfedf723c17f21"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "c23bb0b43fb0c39d4c9d2cce0cd38334fa7c253130f0bda3007d9f7d2dd451c0896ff4265ee2cc35024fad282f9ccaa398c19874775d9cabbb786843fae155d7"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://beanvalidation.org"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://hibernate.atlassian.net/projects/BVAL/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jakarta.ee-community/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/beanvalidation-api"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-oidc",
+      "version" : "2.13.7.Final",
+      "description" : "Verify Bearer access tokens and authenticate users with Authorization Code Flow",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "a9a168abeaa144f34d3993043b1dc457"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "ec0f6f044fd08e4128ed72a77e80ec9f22e07003"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "22d1e7f353f8df251857ebf73d5b6b01cff23e0e98267cb2c631633c1d86806a"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "5ad1238dab976ee0d2c696b50ecdd739c42e656baae5158e1396b1d94e7e507cd964e9f46aaf97546be780710afb7eb355bc8dcf338af833a703be8ff03a0091"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "12f516a89395f30c4b0dc6ef1608ab9abfb8b2a2ff72808a1cfa816d6192bcf143a4634d252ff268fe0387dce2a620e3"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "0f1968c7daa105c357888a67d0bfbb01c8bf0ae978f3368768204b44efd4f02f77bf13133c84dc752c72136d5d676e1b"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "aa8951b162095ecf17a414d73e167f526e52bb59ce8cefec2d3858ccdba444c2"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "e35a9a4d321c1e263393d3fbb3f710ff0e9c34d709416c7f990f2a3fe81150f4b6f4080fde313d03925417cfe070f45617b86216aa592774dba98173cb0f10bb"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-oidc@2.13.7.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-oidc@2.13.7.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-core",
+      "version" : "2.13.7.Final",
+      "description" : "Quarkus core components",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "09667461df5be548cb423aa77dbf1358"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "2e1fa3310b58f1a0cd9164c405149ef1252c66d8"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "e469af5e24ddac3f1ba80ceef53683143e0c6b1fb2f8259706859dbeb9ef1758"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "1744f9c39078b3e7e6d6198330daf12354b703253f85245f03cfe1f10b597c9085e006f12d6328f2932e9d3b6bae09b82c5f1ac4041ebdb63421cd375796c70d"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "4c33e87d74dcfbbfe6e6e9ba9ae65a5a5a5537f1c8f63e74efd1a87c91f4897d064f7fed286ffadda10f2431aa3b138b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "5f143b38b78e2a1e5c1dc3af13db084cc3eda6409bae7726010af3c4b08e33845d7ca0c5435e43a3651956222abedda3"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "7516fcb856c4e9da095d439ccd072009ff8d36f663137c0813d888a8e44dfb21"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "609c1f0ba216cab30d7af3fcfcd0c408b5e08530461187e46a520a77092dbac6abb6d30ff697542c6498d54ea19199f783f010a90763f7be4313229fbd4f9246"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-core@2.13.7.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-core@2.13.7.Final?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "jakarta.enterprise",
+      "name" : "jakarta.enterprise.cdi-api",
+      "version" : "2.0.2",
+      "description" : "APIs for Jakarta CDI (Contexts and Dependency Injection)",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "ff8956b6aa6e32e6f9064597d9c9f1bd"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "58f497f362cd19c2f8842d75c491d270f0600e7f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "e71bbe0e4cacfce5b7d609021344d883531aa3e19321db17390f849fdb04a509"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "d1d51ee835f7abfd87c4df3431ddd99d9c0603cf4efc129215516379a56a23c907a0503727bb5b604a0a88f887a5c6782536724e823a6f1e8331df4fa391d217"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "d2f9399e0dd05773168b18993e7c00887ea02f689276d34cf5368f5100a447209f1f5fb5188b82b835b22d448183f078"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "472ad1589c164f82d7d2764eee2c4cd6299a1c3a849078b60ea05529d6d18d63a602b81cf47dfa9195a611d07ee3e752"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "8a58e19128f278cc5c66198e2ba48c84ddd6bbcb24cd874096e43347c54305c2"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "5b386c90b6b94edf2ba682b2aff63364f8cacc2c2ce33cb5ac0bf1898420a7ce33827550b6569f54a54c45ebe8d72405dd5ed6a7eacd5a30a763d68b847418bf"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://cdi-spec.org"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/cdi/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jakarta.ee-community/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "scm:git:git@github.com:cdi-spec/cdi.git"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "jakarta.el",
+      "name" : "jakarta.el-api",
+      "version" : "3.0.3",
+      "description" : "Jakarta Expression Language defines an expression language for Java applications",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "528ed6138395d22fb54912b2b889e88e"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "f311ab94bb1d4380690a53d737226a6b879dd4f1"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "47ae0a91fb6dd32fdaa5d9bda63df043ac8148e00c297ccce8ab9c56b95cf261"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "f76c94036f0f49d3cf9d1f90697fa96a97d94aba93a0dccad7b907d6c63ff3bceacc6fd40405ff68d6c248b13d056b3543ccb3d2b405917b2ccddaae78ad8900"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "5796acb1f22b55e2713763584eaf2b62abbcfcee85530138006fbb55abb19b2c534b2887c28a2f5301168783416fb6c8"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "bdb09cc896874c0a4a3c470e355f2b23f954800510986753cfc2d4da41cb6c4de567b9014d618da3f89f04e36cfe620b"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "4fc4437d2638002741f4217003f3a9de47c037458dbeabee1a1a5bec96547466"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "5857452b1eb5e9ad141717dd9e989763e99a98bf49150ebeb66c423daee8e890ae9b89737abdebedd7ef7e47e6c2fd8cfeaa9276014fb6dc88134ccd2234ab5f"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "GPL-2.0-with-classpath-exception"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/jakarta.el/jakarta.el-api@3.0.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://projects.eclipse.org/projects/ee4j.el"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/el-ri/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/el-dev"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/el-ri"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/jakarta.el/jakarta.el-api@3.0.3?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "jakarta.inject",
+      "name" : "jakarta.inject-api",
+      "version" : "1.0",
+      "description" : "Jakarta Dependency Injection",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "2e07624f1dc24ee8f6cdd69b0aa99ba9"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "93164437046e06b4876e069b8e7a321a02f10a2d"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "3655ffdcdc058816632666a8bcbcf4bfd09751c6a77dedf70619f37294abb01f"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "4a7fb12ee1e765404e6ddd1ed02e92f26173e6c6ff418cf6250b356939b734ed43a41b3d9896136f8cadc1e46d9b2d83c38a4279a50d2fa8471aa22a3bc3d9e2"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "b5582ce82dd7fb4e0282af2f7f5cd69f9ff713a1837f0cdbd6970781007eb3ee73a2209045a2552d6d5d98fa74617679"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "90d8839cefd3458fc3aeee84457fff58208bc85fb920918e083205b808d11d4f89fc700b57ceadb0d090014db3a8f706"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "3c194e73253fed256ca975b3cf3c617e3685042b39cbeed44d37ea17f89537d7"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "6e3c4f2a3e920e2c3ea60af37aafce51d798f0403bd48c4de840b96ecf112d587133a2062301d3007fdd9d4381f4c8ccc79cd2b274d68571e5829bef2f94eb78"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/jakarta.inject/jakarta.inject-api@1.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/eclipse-ee4j/injection-api"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/ee4j/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jakarta.ee-community/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/injection-api"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/jakarta.inject/jakarta.inject-api@1.0?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-ide-launcher",
+      "version" : "2.13.7.Final",
+      "description" : "Build parent to bring in required dependencies",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "91cef2136d2253a22a0e2e28ebfc0f36"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "ba65a70c7f3f09cbf00657b4d83e8a1f03d88d11"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "46f858d2b9aeb2f48e0943ab6818d2df41c57bf7977845b60c721f52db5d031b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "b222c9e3278f32ba12b4ef580940beed2acae7935198b24336a2b7065737c7b0cb855c459342df72d3d3b7206ea389bbd98eb373dbfa636636881d9e9470b422"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "b400b9839b85907f4d017aecaf055971843b9b017ca0d6e3199ada89021fe8ca1e6eb21f7883d1e6c556a3ec123e3847"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "2c5e960fa51934d7f7e49c4cf0b889a699fc9e7c901875298b7c3174dda42e7ba34bb59631e477bc0167093081c11377"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "ee4a9193b815ce4499a8041fe7ddca84317aaf390d4b582072cdc1ee6ca6911e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "2fbe7617fd138effd55ceb2ccfd6df27127dbf56e5bd1726706e436173a8ca98c5e9c36a1e67dacc30145bf0d7c9629e40da2114db496a62ddf6213443302efb"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-ide-launcher@2.13.7.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-ide-launcher@2.13.7.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-development-mode-spi",
+      "version" : "2.13.7.Final",
+      "description" : "SPI classes for Quarkus Development mode.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "df3477fa877be0b46c266ce574174048"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "1ab0742f0f325ded7a0894ba78ab74799be0db48"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "c2dba92df8e1c11b996a5eb01e74b8dabc0d28d3cbade34c2de8caebe8641bea"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "b5236642830afee805b29f1fcdd164cc06d882d078f2a7df099e8840438e372fca5515861544784be9558595ae5437694482a37487a98a31017937102a8d1f2d"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ef80c44cf137cc927841295cc47bf47b21206ee22b394b2f6104b882d5b4470808a9e40c0b0f9ce7810dd517519cd5e8"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "dff7e4728457349476edb9d10646dfaa66bd8f60a0bb0bd2ba2c1b020e64de9ef7d3d3ddc805126fd270af49bef1b3dc"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "711fe833c4a75531399ddbfeb2f45ecb5955cb4442e923bcaaa804f1324c6e70"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "aca2c13d5f45d6ccad67a3fc578e3a46dc1210e9e75f7351b4f6e2f0ba8fef0a22dbf2bcb462d2ab9d240fcb931f5be57461588520c9b4241cfdf215396baa87"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-development-mode-spi@2.13.7.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-development-mode-spi@2.13.7.Final?type=jar"
+    },
+    {
+      "group" : "io.smallrye.config",
+      "name" : "smallrye-config",
+      "version" : "2.12.3",
+      "description" : "SmallRye Parent POM",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "40cd312d99fcd527375ee09360d6efba"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "6bcaa116be1880d6667e008c825303b95bf05dbd"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "7d6a36f9eb977712c8922a8d19adeff5be40673920642b119bb30d55a2da3f77"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "01ef0bfafb3280889f1d8f8c35b6d0ee1224ce20e1b61e33158d36037e378d4a8af6fe5886b7957c26b9dd9c1592ef326158f1ba4184ae1e6d3aa740f46b1cab"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "31f134ff4387ad185ea904d29b1161fa71fb533ffb2c0681bb5fc80374b6891d5ecc3d8b49d92b7d5f0c2cf768089484"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "06a333a33c25ac74780bb1a231cf08b5759dd9082ee84fa24cab0d988ff7e8703fd918b18349497d7165e796d96ddcec"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a09390defdb3d7b10f4bf49618613b030f95a5339faedcd996c7dc8b48f0707b"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "9745cc95d517412b3c4e8c0e4138ad9eec81e91461aba975796424f67245ff2f900e931a2a008131098366226b44b5a433e7f4a781d9fb3349989d51a1eeabc7"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.config/smallrye-config@2.12.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://smallrye.io/smallrye-config"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-config/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-config/smallrye-config/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.config/smallrye-config@2.12.3?type=jar"
+    },
+    {
+      "group" : "io.smallrye.config",
+      "name" : "smallrye-config-core",
+      "version" : "2.12.3",
+      "description" : "SmallRye Parent POM",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "7e6dac47317df58aebad6ccfbf8631b7"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "67184fa39d2d7336d31126ac9d6f95b6d25c44fe"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "5d6c1472317bac89be225b6047eb31a513a61da0cc14fff552d5a0b2bb834e3c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "6d910502f0e0fb5171f22f5464ba184ca7ae81737536954e61aeb5f30e578cb5d93d6f3f8b2cb969a437b1da9499f30e244aa8f60c5113a725270b536c9d5339"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "97807f735938eae3f5056c0e14af8af95d2722d3218f8bc536aa3808a753b870c500d94f3262d67b6ab8b0e799401ed6"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "b10fe9da5a0782213deb7c9aa515485d0b8d137788c66daf0d6a7e3646eea61d352d68e322270648b396f1e5ca71a95e"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "41b83f36291eaae2d7fb4b3a788d893c02a93893f480dfc6fb9abe897b2b9068"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "8502f2d31e0edfcb2bc49196f614b776dc789935c4c2c150416a6ea542171eab0f8879062ab21b77cdb09c5aec0fb071f3f5a3db3e392e12211596d49c0f437b"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.config/smallrye-config-core@2.12.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://smallrye.io/smallrye-config-core"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-config/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-config/smallrye-config-core/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.config/smallrye-config-core@2.12.3?type=jar"
+    },
+    {
+      "group" : "io.smallrye.common",
+      "name" : "smallrye-common-expression",
+      "version" : "1.13.1",
+      "description" : "Common utilities for SmallRye",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "64ae3ecbdd0e745dc157bd245e20ed09"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "4058b1d1f186d30f62686c9520a1d131c86a143e"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d602e9f7e40075688518622d9300d985c633b57d3b63afe339845e563a294f2e"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "dceeb192397ea0212d1d4c0772296ab2ca1912d7b315c5b4ec539e6e3266919feaedfa3096efe06d9e5cd829c5734e9024b7945bba2c6b5b8c395f0a17d4df88"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "8f33af565ca104d72fc2aec9285cffcad13261867903f5d0ae70028569cafa81934a0ecce8faff57d7a744f82eb4d25a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "ed310fa7d70c945fc75c0107d423a349fc372d373e91f6d165cb3f2f763a5d13f4bff9c9436787deb3c2fe0db3c8736f"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "1bcdff58709e3e0c40d2ccb55597534a4214b503fa290f01f532ff92f1583453"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "cb3e5b7423f86527abaa2ddfa1125e79208c5ce46c1bf8f19a14d26497ae3970dd4d9cc89cfae93b9223066b2ecce3c0cc26655cab1b10c0c051da5ad2446f10"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.common/smallrye-common-expression@1.13.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://smallrye.io/smallrye-common-expression"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-common/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-common/smallrye-common-expression/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.common/smallrye-common-expression@1.13.1?type=jar"
+    },
+    {
+      "group" : "io.smallrye.common",
+      "name" : "smallrye-common-function",
+      "version" : "1.13.1",
+      "description" : "Common utilities for SmallRye",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "54fe4e8d68fb2b7849de1c5f39a63650"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "9fba3dc08283cd93a5cf83c3c69b5469a6a232d1"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "0534ab6fc52e2d3bd44c5809f336df269fe8ea5df0726edaf92b89254bfeb7a8"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "9338a38c889abc43e44b8731995412b5c123b4b1d90f6ccb2ce94fd236993522fcc6ed8563cc87897940d738f28ad699eeea729f38709e501a4046b563695a7e"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ea25dfbb66628299e105fc7386790557b4de9c76dd9aae9bde1ccb756cab2877fc99c9e538615d322c0e9ad9ec52040c"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "fa3b04879bf400f532a6a571880eceb087dec33ffa0e8fddfc9544c8760bac07e33c95e42a1f3d271586d0ff361da16a"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "0ef9a8811d62d6a2891534640d5b7f639debe1c874f800d4dfca53f5579463ab"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "ef94245f8baff697832485312719984dad2c2d0fe69b8026f2083816aaf8021033e4d6677108b1ec20ac46f91c40a89c7bdae88c74c568396430321c57463e6c"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.common/smallrye-common-function@1.13.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://smallrye.io/smallrye-common-function"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-common/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-common/smallrye-common-function/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.common/smallrye-common-function@1.13.1?type=jar"
+    },
+    {
+      "group" : "io.smallrye.common",
+      "name" : "smallrye-common-classloader",
+      "version" : "1.13.1",
+      "description" : "Common utilities for SmallRye",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "0535fb224afaa7f0eff93740ddb2b984"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "f476e48a9dfd8f97bbc5b739cd4c5a3ab2e5cd26"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "5eeeb050679b6b6d6b6fdfdc946f8d6f873a3dcea9817abcef2b9fe2a025058e"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "345ce1776f77ec720c2d5d3d9036856130b969f12b74e183ec008102bd2ed12e5e82b38bf5b6d6fa8392ce23ce455aa8ca17e035400b1932bb2ab7c0329cb716"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ce666e3c3da89d72aa2acac2b07922b15f996d19d1df5bcb5f3b89238021a27367f5042bd2cab2cee1fb2517eed9c883"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "851544b3c2160bf8707f305a21d33635aea01422d06aacfc5aac971272d2a81063affcabd5c90f9318d8dc37ecdd0ff1"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "d0cc68fb13a77f46cf83a6d8f97c47fd996ee200d0341222284d8ca5ace18753"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "d49fd652b01b0d53943251aaa60baea907fadfc84e1d8e346f8ae32259d0299955dd58ea5793c30c4209e4f27b12555289a7100ef6183dd24bcc0aab9f1e5cc9"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.common/smallrye-common-classloader@1.13.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://smallrye.io/smallrye-common-classloader"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-common/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-common/smallrye-common-classloader/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.common/smallrye-common-classloader@1.13.1?type=jar"
+    },
+    {
+      "group" : "io.smallrye.config",
+      "name" : "smallrye-config-common",
+      "version" : "2.12.3",
+      "description" : "SmallRye Parent POM",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "1e6a759bccd00ff33db39a3a4a6de87b"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "1cf7173832c77e829cd97c6f2feed3cbe005ffbb"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a1219b8a995dd6de4c87f5d195b543bd07d0846f14216fe3bcbbe33e5967fdc3"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "4d720f033cc5cbf2b683f178938fab61964a769e047382df6c42bd306966b5d941ff415d456b07d2a425ffe68d08da033d4bd49ca07da08a900f53d1b805e012"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "c0ee7110143b4843e21ea8669bf7d14ca680bb79559e5c4471a4870fc71881f306ac43a1666ebe0a55c8befe6d19fe5e"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "69d6b07e138df584649eeddd6346444d0f8786658433289cfd84c354ab3bf1f615f801eb229c1c0d66f69b9f3f65bfc8"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "94a0f35044e39e05f1ddc33abd66d87e60120dc8743a43bc2efad4d6c6f3a9e7"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "dca29189f1f29f4c98a8046754a26864cceb9b0e7265c124521c6d0ff5c3a3fb6d4188222a1041c1fb4493cac6b93b6a9357e1e8bbb8c5b9e7a2c00112e3db66"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.config/smallrye-config-common@2.12.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://smallrye.io/smallrye-config-common"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-config/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-config/smallrye-config-common/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.config/smallrye-config-common@2.12.3?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "org.jboss.logging",
+      "name" : "jboss-logging",
+      "version" : "3.4.1.Final",
+      "description" : "The JBoss Logging Framework",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "52ee373b84e39570c78c0815006375bc"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "40fd4d696c55793e996d1ff3c475833f836c2498"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "8efe877d93e5e1057a1388b2950503b88b0c28447364fde08adbec61e524eeb8"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "c17b8882481c0cb8fbcdf7ea33d268e2173b1bfe04be71e61d5f07c3040b1c33b58781063f8ebf27325979d02255e62d1df16a633ac22f9d08adeb5c6b83a32a"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "1a9a57638b6d9da1f50dc92da88405878885ccfc1cd6e3a66f5cee1fcef5af51a2d63294afd23f2300f550758af58469"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "aabecb31aaa548a5bf9ed6f540ad91e8f3c713a10c351c43aa71e845f6f80d81d673484e1c566ab246c80c8c77acfa74"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "447c31f632013a87e7e9e90a346b2011f2213df22a3844a502e813536f14611c"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "1b34af205a56d3f93d2070e335ef853090fb7dabe630b05beeee13c8596503c2f242fc93aa7a8763418771bc3593e65e8bd93c62288324e29caaf53ffbee27d0"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.jboss.org/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/jboss-logging/jboss-logging"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "org.jboss.logmanager",
+      "name" : "jboss-logmanager-embedded",
+      "version" : "1.0.10",
+      "description" : "An implementation of java.util.logging.LogManager",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "d10d28a0eb1ff9e9ef9379410b8154c3"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "458edc8e3147cfbd5f5ec2ee694deba6abe1d6be"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "adf131d8fa6004a2db6558544e1d22bf8bca08215e87a952a42ae9e2523a16e7"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "8b5695bf4e35245b394de11a979fd6f0636175e322eacb14f44dc9d3010ff35791f06f23968ee464be4cd8a3d0e48a178ba77f9f19f4eb6317211132a5c4d5e5"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "7f4e55c9c70bca00c4ab60c87076bc7448c81338a10103c75cad4bb888f02c15a20482406da9c1c620f0d4c7ec6d2d82"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "62e97f4e4e38580d2dde0369f9d9620a6bc5676f2f8c22188ba5592e072f0dded2ad8a73a8df3f25e75b883563b1b6b9"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "6e9a92995c1ab3584122f32cb1fc0bd40fbfb9a6200f0a15c1186d87f2e20d92"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "df9ae26ca03fde6821635ba5755c4538fd5e29a41cfdac99dda074d6c978b670368ed98c22419ee392373395ab13d82e26fdfeafb8ff8157e227408d08b0224f"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org/jboss-logmanager-embedded"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.jboss.org/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/jboss/jboss-parent-pom/jboss-parent-mr-jar/jboss-logmanager-embedded"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "org.jboss.logging",
+      "name" : "jboss-logging-annotations",
+      "version" : "2.2.1.Final",
+      "description" : "Provides, via submodules, a base configuration for JBoss project builds, as well as a derived configuration supporting multi-release JARs",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "65ea45ee652a89f43a9a06bd8f0e5139"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "ee3db82d956ee22c4f1f2df9c611e048e79a4a43"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "f1524fc9d7ed3afc87d365ab0d280ef260c8dd1836435689e8300fd5a51ed178"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "81a9c364bfdbffa50920b91730378a704bc8c73748e028e032d4a5938b20875de47d601b1a55f451530fdeef8cf2a6199285e755682f6f04df50b61fdcc79572"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "c63d0bc5a2abb7639087a5559bd55cc344c52589ad98f956d2199dd19e73c2154059e1c4b078ecd88527a465f4e90412"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "c7ccbe80e22ef72215d2ec0e17708d28c0282472841c01442e9fb17a85089a91427904e6e3a5949ee14b1a91856135c3"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "0bc405f4bc71ba6159e5680bf9788c8075f24af81cbb03aab1a7b8a6824a3cac"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "d86adeaf631775d155e2768d7f65fe1deccb3e3c68bffb271808fba1632a4d89ebe81797c1f1724876e46519a790cc7599d2437097276e5e6a6ef57bbf9728e9"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.jboss.logging/jboss-logging-annotations@2.2.1.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org/jboss-logging-tools-parent/jboss-logging-annotations"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.jboss.org/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/jboss-logging/jboss-logging-tools/jboss-logging-annotations"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.jboss.logging/jboss-logging-annotations@2.2.1.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "org.jboss.threads",
+      "name" : "jboss-threads",
+      "version" : "3.4.3.Final",
+      "description" : "Provides, via submodules, a base configuration for JBoss project builds, as well as a derived configuration supporting multi-release JARs",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "ff95ed49f2ceea0512dc6a4284d9d976"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "2433a04e5a0f8982454a2bbe2700ee272a3a71c2"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "bcb44133a0d3b94282aa5ce32a686db5cb9b7f069de4dd2f75c07d93d29b7c0b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "db57b33c01ec49d21f44b0b059d6b9cc0ff7d793b65cab6adbed2e43ea0eb4919fc0c4d183c976b562705ca29f4b64a0342365d1709addb5a7a7cef388b3589d"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "fbb587e6fc4d1e25d27bb016de9a6967779e328f50e955c589c5284f8ec1e580182f09f44c2bdf63e1b6dfd886b02439"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "4d80fc6b699d18a8751cf2400384c3afc44dd1b2d9b002273486ef096b4a16f477f651d4c7b89c6675a2bd7c7e2a664c"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "cfe10a80063744f4231ffb096ab08b5e1cf7a60f58045dc0677d8b657cd5af51"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b29ad5074d12bd7708ac0a5fe47f8717d00973deedda314fc9b24b2eb3998302be3b9103bcbe57787fcf6f3681c7e29327ccf55ea1cc5d587bedfb191eb6b9ff"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.jboss.threads/jboss-threads@3.4.3.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org/jboss-threads"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.jboss.org/browse/JBTHR"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/jbossas/jboss-threads"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.jboss.threads/jboss-threads@3.4.3.Final?type=jar"
+    },
+    {
+      "publisher" : "QOS.ch",
+      "group" : "org.slf4j",
+      "name" : "slf4j-api",
+      "version" : "1.7.30",
+      "description" : "The slf4j API",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "f8be00da99bc4ab64c79ab1e2be7cb7c"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "b5a4b6d16ab13e34a88fae84c35cd5d68cac922c"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "cdba07964d1bb40a0761485c6b1e8c2f8fd9eb1d19c53928ac0d7f9510105c57"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "e5435852569dda596ba46138af8ee9c4ecba8a7a43f4f1e7897aeb4430523a0f037088a7b63877df5734578f19d331f03d7b0f32d5ae6c425df211947b3e6173"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "d8061c2f86f33b813cb86d3d54c615d26aa89afb43cabf8d828ff6a3f4f8e63d4a3b27355033f67ba60c2cdf2558d9de"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "9f0fcb3bab20dce3b4cd094145976ce7c9da8702c891ff6f3882072c5a0acc763aeb11c446ef08a80e1bec695b11cb60"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "7fd51c94b174d462a8c7ce103ea7b1858e2c0943da8d21b4407f71a250377c8e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "a51d2d7d68a41e0ef1430c90d5b4f182d34be2233b92ad6fc32c1def5504b5089afcbda3349fd401df5d8accdbb0571096e91b2badadcec275bcf3bb0cacc7f7"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MIT",
+            "url" : "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.slf4j/slf4j-api@1.7.30?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.slf4j.org"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/qos-ch/slf4j/slf4j-api"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.slf4j/slf4j-api@1.7.30?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "org.jboss.slf4j",
+      "name" : "slf4j-jboss-logmanager",
+      "version" : "1.2.0.Final",
+      "description" : "Provides, via submodules, a base configuration for JBoss project builds, as well as a derived configuration supporting multi-release JARs",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "c05dc8cc28c4de74caeecaff502d84ea"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "baff8ae78011e6859e127a5cb6f16332a056fd93"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a6e925ae7df61c682939d22e90d868910d1d123f2dba6260f197ad585de60eeb"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "e313efe40724224e854f215f5867a94df19fc5b40b432381f897d6d56279d040147fad79ffb490c8d2b2f8ec4d310831611c2e809a692629d7816ad026267904"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "3031ff774726fe71d100b387ca8194639cdc9c1ac30fd641cda212a4afd24ca2dd435e273f01baf94513b4f43d1d7ea7"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "8735fbd597e4c997ffb4c404647f00ad72d4b2c25076c6bc3be5696b4e592c6ac1baec0c7b2a06d887d481c0d0120ff6"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "9dafd71a40c88a02b31f12bee833aabe45d08ba18c13a076fa9f9d6d540144db"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "ea3c2ce3e4d3a2b838650d598d0f4d595cdc0b7ff70a907f4c5e56a0429d2718fafa3f947c438d7513ecbb39f5ada7c1302f716cab56e936aff625f98242b056"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.jboss.slf4j/slf4j-jboss-logmanager@1.2.0.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org/slf4j-jboss-logmanager"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.redhat.com/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/jboss/jboss-parent-pom/slf4j-jboss-logmanager"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.jboss.slf4j/slf4j-jboss-logmanager@1.2.0.Final?type=jar"
+    },
+    {
+      "group" : "org.graalvm.sdk",
+      "name" : "graal-sdk",
+      "version" : "22.3.0",
+      "description" : "GraalVM is an ecosystem for compiling and running applications written in multiple languages. GraalVM removes the isolation between programming languages and enables interoperability in a shared runtime.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "32a6e8ee74a54448614f0a9124378e15"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "83179e3310a2ece87266923fede5ef7355c68c9a"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "30de7b098642c64767d48a880abdd1f1ef149fc52c1a69f155acff6a8d406cd9"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "1da4dfd548a7594251a198153849e1fe469d68698aa171218471fee615844e3d7b4d1a4f0819b4174903bac563e5e47f19af8fea7be12a48dc7e840c9fd2c735"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ba6185c7900bdb54024719dea935b760bbf98f37fc3cd347a9710dd1572497e7a7525fdaf27735fc8b35460c1bb72a40"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "f7c634229f5fc0cb3a1bb80e9d3cda6013ba325038e0ff7645ea34ee2002b77d06f36f161e72e3451b026e10371e6d5d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "82f3703bf09c9ac8aefb3f9d701ecbacb18bda4634d88c3c76ee369d23d6e769"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "39d349db44246937b068f5e38b2568a34c9c2d403d2f72371409b16953419874de5a5f4673e262cdace80f5ef3291b0d2df3a98b45ef56b2146a4f15a850d018"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "UPL-1.0",
+            "url" : "https://opensource.org/licenses/UPL"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.graalvm.sdk/graal-sdk@22.3.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/oracle/graal"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/oracle/graal"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.graalvm.sdk/graal-sdk@22.3.0?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "org.wildfly.common",
+      "name" : "wildfly-common",
+      "version" : "1.5.4.Final-format-001",
+      "description" : "Provides, via submodules, a base configuration for JBoss project builds, as well as a derived configuration supporting multi-release JARs",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "8cf2730c4d707939cbe16a1b7e846aa3"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "d600b29d51306b30b29e7de64f6fedf61beb1808"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "9884f791f815d0fed8c51771af71164afd48f96e621f26009f9ebe791c053f1b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "0b25be38b95b346fcbbe0d6508ee4ed2f50931491ffe3cbde32bddae0bd8893d14c2e59ad86915802cb67f6762965c0d6f5dbd5a84ae4941283964f5ad2cb5d9"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "b5077edeaa28c52af348ac2c4da05b39f3e8537c576f8a8981f13bea4ca5aaaeff696d5468db0a0636ac5c6a39d55a6b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "453c01d7083395d91d5526a33f9db17ea1e49089867683bea048dd69a198234813b5d84b52b8f6a2aa84a64b0137af92"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "071eabd604f4fa0ca944682d3e4cf6f80d321db4da1631db480d76eb2113bd7a"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "0332241277ee28a491a9fa04882e5277cc6f0d938e172876153b891ab1540c6e2d4514a3dcd9264b56e4a7f38e9f7b8bb49bbc8f6f6e9182be097ee67305aeef"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.wildfly.common/wildfly-common@1.5.4.Final-format-001?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org/wildfly-common"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.jboss.org/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/jboss/jboss-parent-pom/wildfly-common"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.wildfly.common/wildfly-common@1.5.4.Final-format-001?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-bootstrap-runner",
+      "version" : "2.13.7.Final",
+      "description" : "The entry point for production applications using the custom ClassLoader. This contains the production ClassLoader code and must not have any non parent first dependencies.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "f84f4e6df1ecd7cea0504f1c1661f294"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "c5d309661b18b7b8d7f651ddcce409024af83531"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "61285fe776c8638f62e476efe2d45554c8d1067135fa8574176d74b703299391"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "b40bf50b35392b4095054a2d7cc161ab9947da1fda02b24ee19185da59bcb5b76ac5f9803cbbdb2d61a6369b2bb342338b8948ea06be5346750da64c3a18eb38"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ff4178e3398ff0f81b1bd07e52b05cdcca2909abe08fa0c00cbae66726591d544ca86cfbb7eaecd0f111d42a14c021eb"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "2bf73e5bc99571f7c8b397c454b1bc0367fe7172451c07303aaa6f39b75ce055bea5e27b6845fe9b04f11777f233a75a"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "c23fc394f62fd4eb40806b5752a84b2f1d1a608569a11a3b707f16a39ebb1bc8"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "10ce55774d6a4a820a2b8ae1afaf460078c9b3f65569adcf315528daeb1149551f551f64577aa38a6d864a56f0a1a9735a84bae80945a4f1c8e75dac3ebbffdb"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-bootstrap-runner@2.13.7.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.redhat.com/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-bootstrap-runner@2.13.7.Final?type=jar"
+    },
+    {
+      "group" : "io.smallrye.common",
+      "name" : "smallrye-common-io",
+      "version" : "1.13.1",
+      "description" : "Common utilities for SmallRye",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "38d561d173ca5ac005c27ecffcd2555c"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "beb9260dace36b10b5cd4bbd329bd4413259bbea"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "190d544ac906c23b73006c3437b10d7ad54ab56d795b80c494dc323a2a364d30"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "52d1346a0d8fb86cd266e82f76415feadf02b0a4b5b2634c040f919c32b9f227c95989789a6bc78e78be32653efe7f53f52cb44b6dbe37314f2e4918272563ae"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "0c3084bf4e0050d70bc4bb293c066056e7b79593b20f8c46c74ac257d31bcf3f0ee9f50f40bf3354853ac00b56ba32ca"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "3381ede01e6176fe45b56b5af243cca90789c77be636e3ff190d376cffd7f7da53933c4da30e7b140ef9742b80422f5f"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a100dd56ccc9b2afbcf44da255e572ff06e356e72b5c1b81f0fe3d5b79de7249"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "abc77b695f3ca62ab4083851ae39673bcf9731db1929abc233dec1a0619339d8291d8d77bb7db3ed3aaa4a7c5caa4a12fcc585d32b730a639c8b93329fe8679c"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.common/smallrye-common-io@1.13.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://smallrye.io/smallrye-common-io"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-common/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-common/smallrye-common-io/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.common/smallrye-common-io@1.13.1?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-fs-util",
+      "version" : "0.0.9",
+      "description" : "Quarkus Filesystem Utils",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "c69d9010050e0c96967794a5a58280bb"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "af43a8b4da2a2c9119e5280929887445847597a0"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "ea0a3a3b46ba0d60eee318691f6d9dda4d0cd47d208512b90d83a62d4ecdca36"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "49b837b883291252137a9924b29959603fd0bc3d13f67055582e846e7a6a15d14800680ddb623fe9dc8be1b69d0ec076bf5bf8088b6308d203d25965831889f2"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "34b134e5e721201f568c6d842d18e3caf19ada6327aaa12ca941122d0063e564abddc8e6eb0864238b1d690dc574e24b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "09162230f0c5bff32064a7653ec884f2eccc10147f76fa9a7ccba632fcdc4f40de902ae26381cafbb2e095a8c1bf42c6"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "1a220fca11fe4b311acb2af2fa4b19158d7663820cff46201ee6a95983c77865"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "abbf3315c28e4cf9be4be67dcdbe1cfc8759fbd2fb57bae17e0ff5f94af9c60d5ad27929d868b586f3c0d224cdc030b8a143992955f8a2e988b854b9daac5936"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-fs-util@0.0.9?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://quarkus.io/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkusfs-util/issues/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus-fs-util"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-fs-util@0.0.9?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-vertx",
+      "version" : "2.13.7.Final",
+      "description" : "Write reactive applications with the Vert.x API",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "6279092f07c7900e5c7989ae3e1f51c2"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a3bf8d8a2e055554512deb35d2704c285578a655"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "23c786f692a2663ee99bb7c8c0a3e1b34342e779670d9705066198c6f00ad757"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "355bcce4d9887019299d592622fb5f417f515765fbb6867eacc73f7dfcde3437ff62ce72e2499ad04ba834d442033bdc0dba5de54c38dbcabc770bac034a2851"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "5a502a2a8dc2bad3a4a4f6e866f6a75e96e1d08221d42e040ff9ed1b06e7223084d3f5c4971d86c3ff904cf38fd9c030"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "ff60ad05e5235678add7855d7d6cb886c447b3626c1be3af1619b66542236cf22ebecd084d086e3fdf63e89ff497ece9"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "02778962bcfaf7ff672d198bd4bb80981b63f48954b9489baafb612dd40c3dd3"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "27578e99262a954c269a4c1ce10712b91c762667f732d40c5e7b9967032122070782d3f4c4a3fb2395954f3abd88297edb2bb540f6c6710bc39aaef9d06e9a06"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-vertx@2.13.7.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-vertx@2.13.7.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-netty",
+      "version" : "2.13.7.Final",
+      "description" : "Netty is a non-blocking I/O client-server framework. Used by Quarkus as foundation layer.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "813aee2892568f5f622edf0a724ea872"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "398c92d3a09da4526274950eba742448c27318dd"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "91addf2b8a3d85e2955d3e6c97ce3f018f74c1f7eccae04e63140d3e09e86165"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "f73925a4c72ca499344c59845980b1dde89c7db3d3cc10477853d7f3670a948e7cf34be0e631ea48d8475b108384133f31ee0a4b0305a7413bd8aaa8e403ff9a"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "6deb39249246e5f4b62e3382aab05904fcdc9419e6787026a3eb63ff2ea0f8a2521b9a115490aa830b855916e16ee11c"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "4c4d4d23203a01ee2ff640f5167c0e84c829b4abe42990bad6f9bb3e2961b6af20cd756283290fc1be70ec68c98d3afe"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "9673a96aabc900b911ac7cdff11401f6bcfe4a2bd1074d51d144ab226bfd8262"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "261caa943d3c8cdd66e9f1b3c06ae7fb24884ec4c342860b05c2b8667c8e00a384c477a0d27b3b8b52880ab051dc631ea62b29ec513d2e1eabf4aa1be249a5b7"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-netty@2.13.7.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-netty@2.13.7.Final?type=jar"
+    },
+    {
+      "group" : "com.aayushatharva.brotli4j",
+      "name" : "brotli4j",
+      "version" : "1.7.1",
+      "description" : "Brotli4j provides Brotli compression and decompression for Java.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "0568e02d5ac618f7f7ce6d3ed41fd9b6"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "1f78152ec75b7072bea10a32ae0605270e08a18d"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "966a47f34e63e15a210798e6936bd70d6e2a39cf6dcab87fcb3293299ec16e8c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "72d7dd6e2efd439212e4d4cfd01a6583dad90c058bba385263bb4632bfba26eb50c117dab34feaa9ae8f1bf5f91c5998eb4d2dc2551eae95e6c0fd4f2aec2579"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "43461f5657a613cc1bb0f2b8a9543829d8c545053588cae72cc85a53fcf68896e79d68324496aeff2a69a23518101b08"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "1491e637dc658aaa9c52b6626643cb8f360b09799a3ead80e9b52e100b098f4a8bfc2ad832f3ea363b936aef5ee635ac"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "2bf0fc6db25845d9390eda05bbf0c21b1a0f764e2f2e43a7337bb1d2d9624076"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "9c321235cdc6ed8c29b6ef4420dc08f4e09a1920254745be19da2c495b38aba34fd3a1f0bbd9e1a67af016bfacfdb85fbdadce2b1d13dcc300856a1edc9150db"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.aayushatharva.brotli4j/brotli4j@1.7.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/hyperxpro/Brotli4j/brotli4j"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/hyperxpro/Brotli4j.git/brotli4j"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.aayushatharva.brotli4j/brotli4j@1.7.1?type=jar"
+    },
+    {
+      "group" : "com.aayushatharva.brotli4j",
+      "name" : "native-linux-x86_64",
+      "version" : "1.7.1",
+      "description" : "Brotli4j provides Brotli compression and decompression for Java.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "6aeddfcc5575164224c2e125dedcb493"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "f08c967e73dee6b5b132ed83f9061ac1c034b20a"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "49c4f0f1311afa91918ec58820226338e7c73cbb5131c2e8126f87254671e051"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "0b0fc0058772c30131882230c0a19e2539914b230481624deeea2a0a668327e143e63aeb9b2d626b1c89563848a06932c48c3a0612a54b99ca807e33c9ca6913"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "09277cae087e88f0abbb09cf1dea4a817b6b95dab8215e249c99bc3f59f3b9c3543a59e2219139a8aab3e1be942e5e92"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "01e9d9c4349d38a1292f772cfa434dc0a06c5d8c3cb5f24d71504e8f700a9bdf1d5763898824f4914e04b945e603bd72"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "f16fa9778d978b8050d858bf73017125b62cf02c6ca65176bf421c3430dd7a01"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "e261a071f7e689f4b0e7818c80545afd516f80bb7fa3a452ed4f0c4b7a61f494aad6eabd5e24cd218cbb3fa1dfbfe35f5510672b94a9818fcd10fc48d3bf5401"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.aayushatharva.brotli4j/native-linux-x86_64@1.7.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/hyperxpro/Brotli4j/natives/native-linux-x86_64"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/hyperxpro/Brotli4j.git/natives/native-linux-x86_64"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.aayushatharva.brotli4j/native-linux-x86_64@1.7.1?type=jar"
+    },
+    {
+      "publisher" : "The Netty Project",
+      "group" : "io.netty",
+      "name" : "netty-codec-haproxy",
+      "version" : "4.1.53.Final",
+      "description" : "Netty is an asynchronous event-driven network application framework for rapid development of maintainable high performance protocol servers and clients.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "77db130ec7060b7de8a936f01b8fb02a"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "3651c2870c1f246942258fb74bda8d1b5215d6ce"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "61893027383435f31dd54b3d5e58421899c425763cafaa3d82a3fd7cb0072147"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "23d13fd37023baab881d85313326077b96afcc9c91eea5c360b7964f177757d464662b002b41d08cd33a8f3e33db3eadc189c346895ecf06ea2561df032a038b"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ddee894aa21aa4a435b85e23cfbff268d831694772d1575c506fb0b79ccfe16f7c1f0cc392d8db5017629979f91401a1"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "2d098e7384355e467e75a1abf560e2f174267ce393dd23881d986154c35d30ba354b6f246655a1864c85daacc085d64a"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "b2d78259f58a79494df4f6047d33f965aace5e78c2ee8419c8cd651490d174dd"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "4aaf8b2b47789387d8d3524dfbc32ac71053f28209b995d61c4d445d2c9d2de196b7a585af8ad58aa97d2a195f80fb653cfa720d881a4a77615d1fb2f6425091"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.netty/netty-codec-haproxy@4.1.53.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://netty.io/netty-codec-haproxy/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/netty/netty/netty-codec-haproxy"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.netty/netty-codec-haproxy@4.1.53.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-vertx-latebound-mdc-provider",
+      "version" : "2.13.7.Final",
+      "description" : "Quarkus Vert.x Late Bound MDC Provider",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "bd5d183d853ee2d2d372172098be1e2f"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "9db3a33ae309b381c7fb1aa92fbc2a0144011a67"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a0950c23d224f37279342bb77e5004e83aa23106ca2745ec7c4a00bd25c49601"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "efcbcfb8344a2e9541048e0545b93ae12e1e96583f2db2880b6c5599bb3a3604859899726b9d9e71e5bcc8c2b021d14c873c1896cd968e921f4ba458777058ab"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "a36ce0b5cf3af0fbc5f797fe11c356d5b8c2d93ff9af8162bd20e74cf28b455b7a011a9f986f18824473e7831e3c41e6"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "04593987664cca7536c307957919660304665becd9eb3f7c69081f2716746477d3efa8f9f613e628b9fd8701617a598f"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "d7efd5fb4150ed15ba69f28c8324205d5ab081d25a02d3cf0ca63ccd08bf7c8d"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "95a2c873c6c8354be82e478143c19188e46df7bc46bc2fbb5840b3e45060ab1b9ac073085541e20cad3026507e7a50ebcca9098ce77cd8aa558169fe910e02cc"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-vertx-latebound-mdc-provider@2.13.7.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-vertx-latebound-mdc-provider@2.13.7.Final?type=jar"
+    },
+    {
+      "publisher" : "SmallRye",
+      "group" : "io.smallrye.reactive",
+      "name" : "smallrye-mutiny-vertx-core",
+      "version" : "2.27.0",
+      "description" : "SmallRye Build Parent POM",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "39c713336cb7345faca175b2420b8868"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "3a37d7daa9b8f8dbc381fedc8146feb5744af3af"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "387c446c783f9b5882602f0022ca5613bcf4807344f699dc757f2775c11cb38b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "2fb70df14c871291b6222fc4020d5f2e53dc66e1f3eeb72bc1c357aa5dd8a4a5dd683d2cd19297e9636eb06b471db2b046fe6a5aa3b7b5769028a3e94bf1aed3"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "f35dc9140026898ea13cbdd13466e1b65c5e0d0d65973db99480789c313bc9767d8bb833eb6a5534dc60ae2fb04efc4f"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "04691ba66fe69bbce74bdfcd1025d7207a379cb8abc150c643dd47c8caa190552b4f15343a82df871d81138b5314e511"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a2b7af4a9aa561ef685a4cef4b9d681f07628555c8fa2295f51d1522494ea046"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "57c08b21b88243f1580db7f1437d7049c14bc8530b7f1ce7b42a6571b3968994f0de2e400edee1c5f4f092c49e1d8eb8cdd5695eb75a8bf0cae275c712687e7e"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://smallrye.io/smallrye-mutiny-vertx-bindings/vertx-mutiny-clients/smallrye-mutiny-vertx-core"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-mutiny-vertx-bindings/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-mutiny-vertx-bindings/vertx-mutiny-clients/smallrye-mutiny-vertx-core"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0?type=jar"
+    },
+    {
+      "publisher" : "SmallRye",
+      "group" : "io.smallrye.reactive",
+      "name" : "smallrye-mutiny-vertx-runtime",
+      "version" : "2.27.0",
+      "description" : "SmallRye Build Parent POM",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "a2a0d0dd45f6a8ead18929d1be0571ce"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a345633c7a8ade41d671739b781fb6692845d00d"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "26597a70aa86d70df83ec3bd74aa231e2f020f3a39b4f4cc001d773bd15dca3c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "d576764e874dc58618b5c371e1ba6203fa10f6bea3110a157ce2387b8c747b23b833744604ba90030938f259393e3ca1d5ce57a84911c34557c9140783305571"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "5328d115d690157dcb25a4f347f62c6b08f5c9fc0a05433fe611c4796b61c21b42a86cc02a29a905e6b03eae020ac708"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "17f608af9a8298b4fa0002b70f2ba695ee737788c6d18d7ac553c7d56d657666bc3c479f89002123ad1999523b91e3d4"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "14818ce3b6a52fa555888edf78318d9c7d5986c15cd5f26bcbf4dce9ffb75a80"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "de0a64b6bbe5660c08c7c56fd922afc1c67f6316b034b79e5488d336bd0f9b1edf55e9224ef59aef98eaabeda79a9cfaeb7bfb7ba5616c4b2bf86fd7eb707e6c"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@2.27.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://smallrye.io/smallrye-mutiny-vertx-bindings/vertx-mutiny-clients/smallrye-mutiny-vertx-runtime"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-mutiny-vertx-bindings/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-mutiny-vertx-bindings/vertx-mutiny-clients/smallrye-mutiny-vertx-runtime"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@2.27.0?type=jar"
+    },
+    {
+      "publisher" : "SmallRye",
+      "group" : "io.smallrye.reactive",
+      "name" : "vertx-mutiny-generator",
+      "version" : "2.27.0",
+      "description" : "SmallRye Build Parent POM",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "ab05cf822a93c6e5f4eae44c90a2be9d"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "81166a4143701967d82e2240a0443bd632051999"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "b3010f9d9b691827dcfdfb43aa142c729d02198c1f7df574a68ed3521398f2e5"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "d2e6ddec8429c4d3a9b769b1b366c76b0ad06114ca594078c4917baf8417540774e3c53c505e782be929a951c05fc35fda41b53a44d848c7b361247f10ac69ef"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "733b0dc21c290f0b9aae86c436cdc04a9fe93f0a19b5d6a89bbfe582873c0a26887031e58f41cac9e494595b6b46a5a0"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "9598c22da5b0a4c48aa5c11e681514326f367ce3ce356dadc4c5f5e5d7a070b22fbd3f80495b83ddb50de18a71307624"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "df33660099cd03f20335425aa3d277f14d53168a82e167dc00a2e9ea1cc84f77"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b0ffb1a39cb0909b4b1251c0c81a0569ab10b3784171c9109f35a38223e69dce145f948504568b94eee1e67cae48cddb1598303af7efe618dad7cb982132c56c"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.reactive/vertx-mutiny-generator@2.27.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://smallrye.io/smallrye-mutiny-vertx-bindings/vertx-mutiny-generator"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-mutiny-vertx-bindings/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-mutiny-vertx-bindings/vertx-mutiny-generator"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.reactive/vertx-mutiny-generator@2.27.0?type=jar"
+    },
+    {
+      "publisher" : "Eclipse",
+      "group" : "io.vertx",
+      "name" : "vertx-codegen",
+      "version" : "4.3.4",
+      "description" : "Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "64b9cd20ef35bc523552f84fafee1b44"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "ea3f8d37ba91bd13e1fca517fbdb15e3d9295735"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "6fbded2c268ccf2fafe92cfb69c1f539eb252de282802586d29e5c8d5f727234"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "44c0499b424a738586a6f57689b446fb025b3e012abf850a748201efdcf2ce65b4c21008986dd1e0dff62eef4f5695c785ff3b763706c41bafebe91c855b8749"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "042830a0e2d29af669793a620e1ce9cb29c88eedbb85ac16e687c2eea70092cfd62af6732e3d81ec07189bf22d74fc64"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "63149b4915f283e45d4eb14135c4bf2f6626c98adc8f1b28947cff8c5bbd3424fd7490d926fbcedcfe1b70be4c1b7df6"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "8c8994eebf301b62381be6ab883220818c2ab86a12bce154a576fccac279a046"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "6c36ab5c4749db92141d07330dc624e71ef9feb49858c80a328c7c96a9aeeec0229bbb1af593c770f8da31c8fca1e9e605a10d641d512782d5a557b7fb0a4d3a"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "EPL-1.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.vertx/vertx-codegen@4.3.4?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://nexus.sonatype.org/oss-repository-hosting.html/vertx-parent/vertx-codegen"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.vertx/vertx-codegen@4.3.4?type=jar"
+    },
+    {
+      "group" : "io.smallrye",
+      "name" : "smallrye-fault-tolerance-vertx",
+      "version" : "5.5.0",
+      "description" : "SmallRye Build Parent POM",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "52fad6806222f1a433e9b7e19c85b563"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "039e60ca32d5fde3b02c36ca29c8171ee569bf80"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "aa37ed981e758189d73cfdadff6faaefa42740f9b3e62d221dc50d8b6a19153a"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "48716d1b5360627183c53b1c6ea6f0e2c110952f774f59d8612f6f2cf0848a965029c5f3f91a77c6c23d993ec5392894c406e8316158a85ea041544d94bdd4cf"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "de5ec04be2117e7e7c92f8204c443c148343710362dc895caded77191386e962fd15f1dfbbbb3d0aafb8a4f9ccc3d12a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "972994e5b6b6675a4533146ecdd4e4c1b9117bb2a968ebb5e4c1af02b374246950f61793b9836d4fbf2f18b73c774a49"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "8eb9982e838bce33b3ba3fdc0bed0447170358cd4fc1aa4b08e1cdbdef0049b4"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "d4d9c3c029fd2ff48f7b94273bfa34a2c5090a402a6ccdf64df0af04965125a861be708b5b8bdd8c457203f1af45fdd6d0b4c9d247677062c6cfa1a59948f38e"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye/smallrye-fault-tolerance-vertx@5.5.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://smallrye.io/smallrye-fault-tolerance-implementation-parent/smallrye-fault-tolerance-vertx"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-fault-tolerance/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-fault-tolerance/smallrye-fault-tolerance-implementation-parent/smallrye-fault-tolerance-vertx/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye/smallrye-fault-tolerance-vertx@5.5.0?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-security",
+      "version" : "2.13.7.Final",
+      "description" : "Security",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "198a09bcbd4ff4921fe858bf1038df6c"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "2234f41c5222c2a25798f989b4eab1eaf13c93a4"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "fe650f556ce8f5418328e735455a48c23fd07edbc0351c0b3db78cb9b276cc4e"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "d93958928cc418e3b27470e4e87903f4a4b4de1ae426cd3f3af07e01b23dc2ec607f9a6eb3013b252671a5f289e720b6bbdf21d5e2cc57a8bf1af9efbe15443e"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "9afc1777e889449664f74959f839c744d5f884767157225d7561fd8373462b3b0cd35d0fbb0cbe601a6d716ee6a03d86"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "6175a375b04bfc7c30ae0b862bfb6762302026fd5b30807445f9e4d657b6f75f2dee7537c55375cf1065d09b837190a2"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "ad03968c28f4530a5b47efeefaeeeaeb9162982c9befb51a5a904a731bb77301"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "fa1171bd66397da742ecb52d0c2aa25ad39e68c30d69f2f6707c6cace18c520aa2501f6e0bb2a34873d4b93aaa7bac2344611d874bbe1aaa25eed476d3ba4e1d"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-security@2.13.7.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-security@2.13.7.Final?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "jakarta.interceptor",
+      "name" : "jakarta.interceptor-api",
+      "version" : "1.2.5",
+      "description" : "Jakarta Interceptors defines a means of interposing on business method invocations and specific events���such as lifecycle events and timeout events���that occur on instances of Jakarta EE components and other managed classes.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "69ab3deaef95f1a6522e7e828694ab14"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "20cbde692c555692ca835fb6ecb4a8c95acbe6e0"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "210c4f0a5a8f387457d58afa3982b9abdd28f0a891e6289b329a6d8cf2210299"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "70f3c36d4e48d52b7c23a5a019e5947b375f8c5c49cf6f305989460217428f62e43b1cb9cadcdeeb61979c6406abd50bbffda08572a048dd45b871566308c1e0"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "de8479983fbe9cb409aefb286a778f58c00e3cc1a04681e73d394e7fff03cb9c2c405961b1c06f328e38be27e22bd2ca"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "8d65c279a249fa0a2d035ce6348bffcc3ba4a6e3cc3543fed8c4d29ea1a2785357b9f19bf55d9c9ce667a06dec081fd7"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "368289095b8324d747b009f448d8b508354eced1abf776d634e75019b4c4c269"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "080b664d0924a44a2afae7c2fee6f314fc991c240c5f727b2e2a6a0d4a0695bbdeb569501c459cf3f15f61ad4b70c087262d8ec155c8cfe3a35b115166843d2c"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "GPL-2.0-with-classpath-exception"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/eclipse-ee4j/interceptor-api"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/interceptor-api/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jakarta.ee-community/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/interceptor-api"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-jsonp",
+      "version" : "2.13.7.Final",
+      "description" : "JSON Processing support",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "997eaa87eed2fe7706d37dda2a62b603"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "48718391a1a272b2e8715b50800cd023228aea9f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "80f26abfdc7054d7adabfda34207ec7e0f0f622bca53796cd4aeeba47142a538"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "a6c2ae421212c3f79fde590150e677ef50c8515f7f124a6cf3fc4b9e17cafeead6a444236458798dff9fe186ef92f9f64aaacce40c0802044d96d5365ec50b06"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "62f15e6323d48e60aee3c84701d966013a8d2f573394f9d19982cb5a0010b055e1387049b222bdb4c8de98de5a463838"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "28846a9e04a08f21cce92ca2af23a91accd930856046fe6302c209e03bdfd7db2c3b186f88828bb27ffcfc552e02b751"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "b6d4a94b53f55dcbae939ac52597f2c8c0b2952c7730fb341ca41b05dffabfdd"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "96533154c5c7e95aaac1766d75c199b2962e1a2106eff1d7709f4cdadcfb7214a156abf2d8dea1fd448ae8ef9bd209c4f8d411d72d950184f121a933bb0284d5"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-jsonp@2.13.7.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-jsonp@2.13.7.Final?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "org.glassfish",
+      "name" : "jakarta.json",
+      "version" : "1.1.6",
+      "description" : "Default provider for Jakarta JSON Processing",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "929731627c96deeef4e963b247089c3c"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a39aba0ef0a70c3f54a44a2c539a4f11c9bb07e8"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "4e1414edc1d6c7dc0747d187c94b451515ed340a9b735156daa91fcefc6aa1b0"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "2c5cdc4410006e0de4180970de815832ab997ed6e7ede6c153327d589913c221df4d9ffa1d63549f0b428cdc87d9b808db340566111ab0c26981c2fe644876fe"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "931055c59d6cbf2f994bb09a511d17e5f8f7ce0ef78994f367b15bbca84cd968d15219953495783468d95d711d2af555"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "ae8ae8c8e445bf809ed11f975548fde8110d808866cc2c39384224542821db2bdb6e72349789a5e5643c3b68730814a9"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "edbf6f209ffe3b369496fb6766f2dac3ef62e30900eb7ce8619e578f8d0cf7d8"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "0b9ffc46c100a5e2a32666b93ba6d2205045c1dbfd9d57dfa506b3d6ac6507d6acec5a802fdf1dd1aaf378f61fa42381470cd35e4652d27a62b38983e020faea"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0",
+            "url" : "https://www.eclipse.org/legal/epl-2.0"
+          }
+        },
+        {
+          "license" : {
+            "name" : "GNU General Public License, version 2 with the GNU Classpath Exception",
+            "url" : "https://projects.eclipse.org/license/secondary-gpl-2.0-cp"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.glassfish/jakarta.json@1.1.6?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/eclipse-ee4j/jsonp"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/ee4j/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jakarta.ee-community/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/jsonp/jakarta.json"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.glassfish/jakarta.json@1.1.6?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-oidc-common",
+      "version" : "2.13.7.Final",
+      "description" : "OpenID Connect Common - Runtime",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "6faf6a0a24c2401a3086b84766e2f08d"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "36725252fa663e004954bd2b6307596840f7a160"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "615c31b1f31af5d3180503a681b33c3e2292e5db15f26fe5ea09c2030442ec65"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "36495a2cc33c35ec654ff55e8f91132733cdfb3e13b6d8ee8c75e97ed6a8668b58d409fe07ddc7885d38613b7f2e50268d9a68bf396c48e74a7917db9ccd382e"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "f09635f77931e304ccc4b2f6de46ce9c10f4f7cfbd8453f850cc6d758cc2e6626888d6c66fc12cbf2506b814c8c8fb6d"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "e076898012edfa716262ad294186db1687df8291ff37b4b6276d5aad254ce128ab63cf5f8324d806363c365cf327f341"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "e89a372d496bcc9cd46faff960ec8a567d2e4d322724ba69e3066a13fada37a3"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "aa36ebb9854a185aa1681b1eb8ced143a511de9ee085f7542f3ecc125341544dadf72ea4fc4e2f2d38011d75bebf5798910a59ef966fab25b4137bccbf72adfc"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-oidc-common@2.13.7.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-oidc-common@2.13.7.Final?type=jar"
+    },
+    {
+      "publisher" : "SmallRye",
+      "group" : "io.smallrye.reactive",
+      "name" : "smallrye-mutiny-vertx-web-client",
+      "version" : "2.27.0",
+      "description" : "SmallRye Build Parent POM",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e754cca4c7efad1a53a3bef91296091e"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "0f89903aac246790d85c350ce0e3ad9dd4558a71"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "457ee549b9b67af0d47ee5a7ab4be1417d9c8a2345ee7f84b3b993b923aa1c56"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "a745c1342e0009b8290b996a73eef5eba02eadfe74365e8478c1b975217fe8bfb82e8cab4cde0851aec565d64ca6e8abd5bfde6b924a416fe2ff11476c9157de"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "daf807b6769f6ae84806d2849bf0c1acb81d102fb1adb6c8f120114b839cacff61798008987a1d6d829712f10084de49"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "ecfdff9eccce7a90991ab5740fc9e7e3ce9d083f418f8c6c1cbda2cc93ae8b1d8aa9a9f9efb9a890d4f9708c668fd293"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "ff056d0b6b34a0dc9f2f0b14d69db887b9e65da7491813152fbc2d11f2cd5f91"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "705ca6bffd863fd6d1e9ec404abcf995a29617ba30bdbea9cb9ff4c612bc16f6a4e57c34b48351871116252b67baa7401a7d42d5b3e2142fadc637e7754a3214"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web-client@2.27.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://smallrye.io/smallrye-mutiny-vertx-bindings/vertx-mutiny-clients/smallrye-mutiny-vertx-web-client"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-mutiny-vertx-bindings/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-mutiny-vertx-bindings/vertx-mutiny-clients/smallrye-mutiny-vertx-web-client"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web-client@2.27.0?type=jar"
+    },
+    {
+      "publisher" : "Eclipse",
+      "group" : "io.vertx",
+      "name" : "vertx-web-client",
+      "version" : "4.3.4",
+      "description" : "Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "03a99ca12aef2986cf7359a1c2e2a78d"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "c7e5553de664439478debf348ae01c6abd9e2cdd"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "302c434e03221942b1fc1b805acd19dac2b7d8ff7f418f7317f435d02916defa"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "77376b153a106fde88002bc787a58d67e538573d55acf22e96cbbfc7ff816a4fe6bbad1d48d1d52a5860d1d20a01706596ce8cb431d3cd1c6cf58ee6e60c53b4"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "03ad89a7203f925f60a3e3259aab83d01df27223202a3ff92eebdba74eec1fbb2f95f08f414b428aed6c7e53a07cb1a1"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "b87730ffaee21d8a05308a47ccca9b01b2c1eb1310f6e36743fa0b376f8c2a5aeb381058ff44341b674612e1e533d53f"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a4a0b124ba33fb34031529f47c56a8fc240b369bd9889947ed6ff5e148992d01"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "3b90aa38f51a1e87d592ae31b5dd5819cf5cdf6c125990c19ba7b2c8bf0475404c1f9d543402798d83aa62955ef808e8c26964c7a7bd90fa09a8c8ffd1d5b9d3"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "EPL-1.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.vertx/vertx-web-client@4.3.4?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://nexus.sonatype.org/oss-repository-hosting.html/vertx-parent/vertx-ext/vertx-ext-parent/vertx-web-parent/vertx-web-client"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.vertx/vertx-web-client@4.3.4?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-smallrye-jwt-build",
+      "version" : "2.13.7.Final",
+      "description" : "Create JSON Web Token with SmallRye JWT Build API",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "7af5e201e96193000bc6523e04a55d71"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "1872218a4c5ab3dcd95054e42436b461dc9f4499"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "72e47e866cc6e25a4029bcda3aacacce036f2f0a1d31a2ee083fc3d050aa3508"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "4ab19d6511a9bcc44acd8325cad6b8ec641f166d10c101f23dac4aadac0c215fe0d9ec5fec2296c927cf548f7e09da48431674ff8ed446762ca3bd0d21808270"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "89695f4b5c443efdf2d47c5a792df9d328c647097dd4da4f87cf33ba5cc1d978e987775992d155da5c8e2eb302abd280"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "95a5d6a35a07c5d0a06f33c70660e30e33052c9e1a86a0a7073ce76061a179bea410d68392d8cd483cdbdbd96fcaa0c6"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "da28e5e59308ee59edebadc1a72620adfacdd6dd5b69b5563a9829bf2079ebc6"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "74576261f7f83c7254863aa2467d218fc2cb3485607a00a5039de32861f586f354e1a64e4498d5a13a59652152f0f8c430ce607d05e899231f465c1511ffb224"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-smallrye-jwt-build@2.13.7.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-smallrye-jwt-build@2.13.7.Final?type=jar"
+    },
+    {
+      "group" : "io.smallrye",
+      "name" : "smallrye-jwt-build",
+      "version" : "3.5.4",
+      "description" : "SmallRye Parent POM",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "a0e57d9fb6db0e2dc157c1752ddf1f51"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "c639386363913cf7a7bb527c7a1a56101656b2c2"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "f93269dd6a221a54b85fcbd360d5afe2445b0d1098e71a8e3d5f722521d31874"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "ec25c5d6da35e44966b725265de839b3a3f3747032a12949f97d63d3f564799399ccee4d92994675658d3413c84d7ff1b4962e2c8089d4ff0cd06680eacf99a4"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "540c6da13498ca1df1c31c3845556903b427bb2e05e8cc659c82b308487c4d002814ea6208f32964f8e116a7ff33711f"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "05e9f5a1ce34395ab944b55ada80bf2c07dcc31ceeed2a7f698c56ddb26f5fad5163d02ebf4b8b44575af858e27a2dc1"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "97bfc9963a9c716ab900d8014d7b783f10c34700f9b69d19136e9536f82bba30"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "431655875db898dc02eeb2fcf3ce23333b41720715bcf96f07b69ebe78b33b8c4ad2c8ea2779c9243f102feb63a929f7b19167ca23a03aa27d0cdb895d721551"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye/smallrye-jwt-build@3.5.4?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://smallrye.io/smallrye-jwt-implementation-parent/smallrye-jwt-build"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-jwt/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-jwt/smallrye-jwt-implementation-parent/smallrye-jwt-build/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye/smallrye-jwt-build@3.5.4?type=jar"
+    },
+    {
+      "group" : "io.smallrye",
+      "name" : "smallrye-jwt",
+      "version" : "3.5.4",
+      "description" : "SmallRye Parent POM",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "99b5bac755b439cebbb8ea5d1bbf5619"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "96e83b5728281b8215d511d0c4e481c453312834"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "f87d811e12ff7dcd3d61aa11bafb8df1cc842305ec284f8060f4fc29695a2721"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "a9c6bae8ac7c04dbbe34ca290eb52b35373573a868124689f0103be5dea1d9ed848df06cb40ee6df82cc7db8d1e9257e353ce589b41e01f3dce243e72c9e8611"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "be3cf86bb9550f3c1e5bfa9b654a0ee5f312a04dbfe241adf42322ff191be8769d813869f44f46cb2fbaff596e613486"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "717f1f4445e297719b59acaf6054c59c7cf83bc45abda78bdc0a8002cf16e1f9b69ef7ac742d685bb6cd397d2864017f"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "0168d1c9e3d867b5b396ea006f10c5b49bf06b97c4fe8251d256c5c53227892b"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "0d37a173494e35f6fc340daa2e57d611675d34ac59c533f873083aa10e7566a90992c00bc9b370782fc1df156e1147867dcb4360fe2fbfa2d409f9908afe2cf0"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye/smallrye-jwt@3.5.4?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://smallrye.io/smallrye-jwt-implementation-parent/smallrye-jwt"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-jwt/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-jwt/smallrye-jwt-implementation-parent/smallrye-jwt/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye/smallrye-jwt@3.5.4?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "org.eclipse.microprofile.config",
+      "name" : "microprofile-config-api",
+      "version" : "2.0.1",
+      "description" : "MicroProfile Config :: API",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "ca38f9ed87c3387b81de49562d1c9b04"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "26fc0aba41ac450ddf86c8d72d58635e89b84feb"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d4040dabeefd10de26473acbdbc2a52419a9228d31b1f9f0561e9e83e1122874"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "9da68d7d99414a2e3a0a06b2e1f34fa821bc861cc36184fbc5315859addb1facfc3675976e1ac225a11a645cf143e53c8ffa2d31d4f87e2e78281b556a99ebdd"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "18372b64dfbcd34288d50269fc87a759b063c04d216a4be4407d4aad3838d902f02a75b70d6027b9f27d079f19b75c03"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "7d68a29f0c5d2d7a81f0211f1c3ce545105e2b987b5d330a829e48298c27241bbb609ca39e3ca536a304ac4790836d94"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "ba63d078616f58abf57648f4bbc70c10cf492375b7918fa8333bf57f7345366e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "e6b2fadb4b7d2faea55505f83e5cd09bb94ebbf983bbe13dd17394e4190de3353d7e9e43ae4aa38679636d51bd2eb2b1928a1b2bdc9249cd43c34197d8dddc3e"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://microprofile.io/project/eclipse/microprofile-config"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse/microprofile-config/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse/microprofile-config/microprofile-config-api"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "org.eclipse.microprofile.jwt",
+      "name" : "microprofile-jwt-auth-api",
+      "version" : "1.2.2",
+      "description" : "Eclipse MicroProfile JWT Feature - API",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e2f81c3353e5c53ff2005a65584d96cd"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "90e908950dd2d98a4bd20e2db6564bf8dfb5510a"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a208ba70681f954533ffd8a8c386d1b34e82c88e7caece48fbf24243010b9d8f"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "6fdfc3729f26d00aa6e9ce494fcb1393fabace8cbbac30e6959896536cfaa34dd60f82253ddb809a48561c713bf7a34a86c1a766d230e3a717fb8a4e2f843c5e"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "0f1180bc99a45fffb26ec3246b39d149ab382fbd28a758964c2b13647c8e4e80c6a0580c8da3f8922ae75513443c5ce0"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "0161f49f2b8891c6125f03100b85dd0064589805f3e554f1b4994be75c2c0bbf18433af6b3bda3df90a23b7fce3aded3"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a5bef0b49b0ee20742ff2b38131cc87c357485e76f54b30916950f504359850d"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "d208b288a1b2fb2c7d22a69148cdf4dd3aae540a13868d96c49632976d8d7c946eefecb85f8bacc1f17abad7cc938cc2974430d8895a8233e3a7f85e3fd8cb6d"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.eclipse.microprofile.jwt/microprofile-jwt-auth-api@1.2.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://microprofile.io/microprofile-jwt-auth-api"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse/microprofile-jwt-auth/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse/microprofile-jwt-auth/microprofile-jwt-auth-api"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.eclipse.microprofile.jwt/microprofile-jwt-auth-api@1.2.2?type=jar"
+    },
+    {
+      "group" : "org.bitbucket.b_c",
+      "name" : "jose4j",
+      "version" : "0.8.0",
+      "description" : "The jose.4.j library is a robust and easy to use open source implementation of JSON Web Token (JWT) and the JOSE specification suite (JWS, JWE, and JWK). It is written in Java and relies solely on the JCA APIs for cryptography. Please see https://bitbucket.org/b_c/jose4j/wiki/Home for more info, examples, etc..",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "a5eca789fa3e2329977dd4f11b6476bd"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "2ade55ada2282b01333b97ab59f126448dc2993b"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "77a168c22d609d84896ffa872800ce51f14be2d9bcb3b32d40b7a6d641e76a2c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "82890c9f70bc4d7862c3b6d3f5edf09c4395e4d6f69f097e4a6c2974be841f1650b07ed086c31abb4d76b3cd599a156ae02ecaaae2e8d880dab1ffab8e519ab9"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "a71cfcda0005f3cf6b7234caeeccc4ec1c5998904847d9070d51678b802e471fb34a143e6c1a4e3c2245e4a5b9042e7c"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "0a7fdce15dccf512c40271dd6b840c57a7f5d6c4b2e633478953f21b8cb7e686c47a43e119905a14da040b45df3923f5"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "e2978052635fd0e67a6330a6bf81fb0e730192b5367193f19396f0d1659a6bdc"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "7a2a9a27d295c27a76a8019c6382f5b2e0fed0e439de6090b534499b88413099f642322d3f34c2bda0f79688bc6e9532b3c794c87994eb140edc6ebf4eb956ff"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.bitbucket.b_c/jose4j@0.8.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://bitbucket.org/b_c/jose4j/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://bitbucket.org/b_c/jose4j"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.bitbucket.b_c/jose4j@0.8.0?type=jar"
+    },
+    {
+      "group" : "io.smallrye",
+      "name" : "smallrye-jwt-common",
+      "version" : "3.5.4",
+      "description" : "SmallRye Parent POM",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "da0ed6e176a6fd1baa0d2deacbc643ac"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "910c54945084c5b8088290f32584c1e4360faa6f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "e45fc988167a32ccbf2bdfb7b929f9921323e6e9612d0952b89b051cbf188b70"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "5c13025a8bf6d9d9bb94aea3c31bd28aa6b656590413b6e20832e18d60800c4cd8c410a79a52708ec505c859f6c277c36aca555afc07e69fe34c9e1236b48bd3"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "fec7ac2d93be00bed344bde0adec7d0d80408fca44c874a1cc6e828e1c7688405f8d022d47b0c5ed35c8b718f8a45df0"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "729ca30ac36532687502f9017a281d0046f77e98609212909696678de999c453b87d77c55c6a638726beef5fad3a781d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "f1ee0beee1973d9e8e48f0d5a59135a84efaa44973f7d78f031066bb9d1b11bd"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "5a19134090fb16e282dbab4ef5f160b9da82ad6b9be50ea7761e704ea5f9d970b2a66592e4224a0f29cc9efa0637741ccaf44bb7251349135dcb534a2cc15480"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye/smallrye-jwt-common@3.5.4?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://smallrye.io/smallrye-jwt-implementation-parent/smallrye-jwt-common"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-jwt/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-jwt/smallrye-jwt-implementation-parent/smallrye-jwt-common/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye/smallrye-jwt-common@3.5.4?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "jakarta.annotation",
+      "name" : "jakarta.annotation-api",
+      "version" : "1.3.5",
+      "description" : "Jakarta Annotations API",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "8b165cf58df5f8c2a222f637c0a07c97"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "59eb84ee0d616332ff44aba065f3888cf002cd2d"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "85fb03fc054cdf4efca8efd9b6712bbb418e1ab98241c4539c8585bbc23e1b8a"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "d1acff146c0f9ea923a9325ad4c22ba2052ec474341ab8392abab7e8abd3ca010db2400ff9b5849fc4f1fa5c0a18830eb104da07a13bd26b4f0a43d167935878"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "004a4bde333c0575f72df1cb9cf95ee0c6c7f738a6f0f723a5ec545aaa1664abeb82f01627708a1377e3136754fb7859"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "abcc5b1fbad59b3e9b6d2d6195ec11d6254f689116c534a964724b61f815cca60ba3a2c1489933403f3f78dc54fd20a6"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "3d3ef16365e7a0357d82f874fa26b2b0a146cf7bf98a351c65ef1586444fa009"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "88625a8811be514851209291344df32478b527bc7838ddee58752269bf2457ae8f4e6b6a0d0b5c18522e287ba6df1def0cb19dee2b85e01ee21f0b48ac2630d3"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "GPL-2.0-with-classpath-exception"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://projects.eclipse.org/projects/ee4j.ca"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/common-annotations-api/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/ca-dev"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/common-annotations-api"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "org.keycloak",
+      "name" : "keycloak-saml-core",
+      "version" : "1.8.1.Final",
+      "description" : "",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "116ad7e9e81c721e2ae5e1902828beed"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "73cebee358d4738326d4540ea496eefa1e5ad05f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "270417621b1042eabba145b90d0056db74bb0ac64a0d2de4fc472aff8aba056f"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "baa368c5058e4d874f6f85278bddf733bb7d47bf7157eaf9ec4139cc2c80799c27fe07872918cc1f48b54f8a73456ec93e9fd76800a5d8d35becb9b2af98d65e"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "97cb47d4587a23038219dc223fc8fc6bfe2a3722ce78b001b8810175bea03af9f31526878dbc4c86523ef239aec61be8"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "c4d81646ed1503e2e43933f7b497a0eea4e55bbf2a200b7e31bde15afc0e00b5b6a810bc709faf6052ce0770df502525"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "026857bb86e9235aaf48e74c6d495f2a8cc8c90fb3b4f5fccb6a8d088c9db22e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "660108ee186e25beefe18392487cfac0584d73bc3ee735745e6417c1f82a077d6a2bed0126aaefae402c7f172ecd870db2307220ae24c84f6ceee874e6b7a985"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.keycloak/keycloak-saml-core@1.8.1.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://keycloak.org/keycloak-saml-core"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "http://jira.jboss.com/jira/browse/KEYCLOAK"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/keycloak/keycloak/tree/master/keycloak-saml-core/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.keycloak/keycloak-saml-core@1.8.1.Final?type=jar"
+    },
+    {
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.santuario",
+      "name" : "xmlsec",
+      "version" : "1.5.1",
+      "description" : "Apache XML Security for Java supports XML-Signature Syntax and Processing, W3C Recommendation 12 February 2002, and XML Encryption Syntax and Processing, W3C Recommendation 10 December 2002. As of version 1.4, the library supports the standard Java API JSR-105: XML Digital Signature APIs.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "ecf0046cfea8b48a12a6063396b2ca67"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "bbf5d96a49a2b58b8988202a3c8728461639090e"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "9a70fb799c3fcaee27d6c05ffb0d17376272107f67665bae3172a86c136a6d40"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "b5381651e068d82c0a42a471d065003c5f000ff24fd960e8620215033525a67fb6ea0c673e61fad40a994e00c742755421480ecca5d4750946db1c3ad8603888"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "38825e3f3b38225b1b8e992942e745c0219331b341354c530fda2d6f037eb6a884da66be493984663a7ca0fc4c7389f6"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "756352ee058afdc4cb9ca97fcfec629fc70858797c1d21555f0e6e3be3359dbf67436e763d1cf382764b1786e9462dd0"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "d84a5bbe443b9d60fb54446854e419ed788a971660328e58e04bdb6e6f18d25f"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "992843c0f1c8cb27233b8d4d009e70a70875d02cf537c61db6db641e9ebd2b42a4b04311195cabba42683ee8f9f08e4ee889c86721308e5aa26a459c1bf1971e"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.santuario/xmlsec@1.5.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://santuario.apache.org/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "scpexe://people.apache.org/www/people.apache.org/repo/m2-ibiblio-rsync-repository"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.apache.org/jira/browse/SANTUARIO"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://news.gmane.org/gmane.text.xml.security.devel"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://svn.apache.org/viewvc/santuario/xml-security-java/trunk/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.santuario/xmlsec@1.5.1?type=jar"
+    },
+    {
+      "publisher" : "The Apache Software Foundation",
+      "group" : "commons-logging",
+      "name" : "commons-logging",
+      "version" : "1.1.1",
+      "description" : "Commons Logging is a thin adapter allowing configurable bridging to other, well known logging systems.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "ed448347fc0104034aa14c8189bf37de"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "5043bfebc3db072ed80fbd362e7caf00e885d8ae"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "ce6f913cad1f0db3aad70186d65c5bc7ffcc9a99e3fe8e0b137312819f7c362f"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "470323a2ee38be1b7ff8c84f1f5a5f8c4ec2ceb6b0649faa7b961f111865877dbe125409f72b1c52c7f18aa89e3469635c49ff4b83f86cc2f2eb2cc5562f9bff"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "264a511a601a07558911ccc5f49ef579aa1b1760bb4091bcbe1a0017c7be64d86f1d0b28ef560819614b252907cdd44a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "e61a9dafb4f92a3cfd76fc28ff340eb15bc0fca939a48408fd9032362b8a95ce938e58dd01f7c3d0ff90ac21cacc77df"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "0799a9105d174ba2f082845e8ca27db236118b00e4a2053ee1fde798b2fbd031"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "dbdcf933551c6abe834ac4fa5b4833e47895c2573530b74f51daff7291dab60db88946fc34a518f423a68e9c9ce36507345070e56a86fb5a567be685c1e3cded"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/commons-logging/commons-logging@1.1.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://commons.apache.org/logging"
+        },
+        {
+          "type" : "build-system",
+          "url" : "http://vmbuild.apache.org/continuum/"
+        },
+        {
+          "type" : "distribution",
+          "url" : ""
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "http://issues.apache.org/jira/browse/LOGGING"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://mail-archives.apache.org/mod_mbox/commons-commits/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://svn.apache.org/repos/asf/commons/proper/logging/tags/commons-logging-1.1.1"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/commons-logging/commons-logging@1.1.1?type=jar"
+    },
+    {
+      "publisher" : "QOS.ch",
+      "group" : "ch.qos.logback",
+      "name" : "logback-core",
+      "version" : "1.1.10",
+      "description" : "logback-core module",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "3d19ba9b1b24c913f3561b946e9dab3f"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "ee683b13d3ca1cdc876cdf8a341c81d04976e1d6"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "4cd46fa17d77057b39160058df2f21ebbc2aded51d0edcc25d2c1cecc042a005"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "7a9538a163e44efbaa83d70767952f0257c82df9a5ed7c494d5f2364f9782afd32e403d1fe83dcef212cb21e7c780e0dca5956c1978bcb27301eef7fa642837a"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "cbb6553c2fdcc0b5418ff996ceb403a00aba685987f091a11f946b1d611b18b2a984b1e68fb5515f84bbdb8eba69440a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "b452fc9cc65ce5899f1dce6ee2ffa58458c00a95b27077c190dd6f84fbe4d8a22d80cd8b9f58b9a721dd8d8d95e28831"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "5341ba77e2505d15a1ecc3d264f921e4d38ff2f727ad9712eb8171b34067868d"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "9ace5ef8466f03c64cec7fe824707e17d707b0343c1ef787eac511631d16db28509f1762653a526ac0c4d715bd502c1d51260dffdf995924a169ecd18feaf4f5"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-1.0"
+          }
+        },
+        {
+          "license" : {
+            "name" : "GNU Lesser General Public License",
+            "url" : "http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/ch.qos.logback/logback-core@1.1.10?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://logback.qos.ch/logback-core"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/ceki/logback/logback-core"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/ch.qos.logback/logback-core@1.1.10?type=jar"
+    },
+    {
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.james",
+      "name" : "apache-mime4j-storage",
+      "version" : "0.8.8",
+      "description" : "Java MIME Document Object Model Storage",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "40514917677d5fbf1d4f68c069cbf65c"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "9172df172cd33de965798023b8a97344b22a593c"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "8fad9c1f95d74ecbc133e4aec190c8a0d7af69e11f547e7de5ac804a161fc4e5"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "3adc6eec338513086d450776b5e07b5795edbccf08a1963c8b4b51e01f996d8a046151a17c622b234282efcaafcf4a7ad124e77cf88726a6d0903e89d0dcbb99"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "d57d83404c81ad8a7bff904c29278acf59157dbac9fb28d095a71b5bec7954272d01cfcf47c1256f5ddbc0bc0279bf91"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "b9452250e4866c6effcea454dc42647a8bfdf13f30d1baca5081fce20d54c634a694a2d2789b8402f6dda1f6f14f377b"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "f4221655bc3ad08cba2485b55d9a2efa210a9a3caaec39969904858cd6cec26d"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "c5f43b5d9f7787d107a1803c5d174a6aff80e61f622f5a25248b99f237df27c13371530562b19f5601bc9071fca10e77396b981dda760d5cb31b275568c1eb8d"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.james/apache-mime4j-storage@0.8.8?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://james.apache.org/mime4j/apache-mime4j-storage"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "http://issues.apache.org/jira/browse/MIME4J"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://mail-archives.apache.org/mod_mbox/www-announce/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://git-wip-us.apache.org/repos/asf/james-mime4j.git/apache-mime4j-storage"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.james/apache-mime4j-storage@0.8.8?type=jar"
+    },
+    {
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.james",
+      "name" : "apache-mime4j-dom",
+      "version" : "0.8.8",
+      "description" : "Java MIME Document Object Model",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "1f6f74d937636a08ed2d73991fde9fb2"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "e76715563a6bd150f84ccb0adb920aec8faf4779"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "2531f3bfce8d81ab203245b42b1910885898ee67d6f1a23804b0efa3ae57cfb6"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "145512f964e69b93478bf6dd5ab113f646f15afc1d758f552cacff8ab62f2b19cf6ede9ab3cd04f1ec764e1b18632747f78871fbbc38a3b986a8cf19d21568ad"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "577e51381c3c8c4782b1e9c880244562d4d9119b2fe34e7a61886acee4500ee5e14ffcb7714f98fa0fc6bb8482264a68"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "4507fdbcf59213cb814a4e53c260b713e8bd09244aa7ac3e377d3531feb2ed5c098dcef3c8961074a3f17996e0552e2c"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "4b562b3440fb8b25db631c0e41fc39b7106aaef0abd97864fd5a7fb06d9ace75"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "89a57e242e76a537d0e68cc14a844c8ccdacea80c56f2bb797159d101d4d50b12dfbd9d9814bbaa57c89a8ddab8a1938d38cc060d8ef778c3bdcf9e5b948a02a"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.james/apache-mime4j-dom@0.8.8?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://james.apache.org/mime4j/apache-mime4j-dom"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "http://issues.apache.org/jira/browse/MIME4J"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://mail-archives.apache.org/mod_mbox/www-announce/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://git-wip-us.apache.org/repos/asf/james-mime4j.git/apache-mime4j-dom"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.james/apache-mime4j-dom@0.8.8?type=jar"
+    },
+    {
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.james",
+      "name" : "apache-mime4j-core",
+      "version" : "0.8.8",
+      "description" : "Java stream based MIME message parser",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "6d2613450a7eeff406266083f4dd7854"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "7330de23c52f71617cbec7f1d2760dae32e687cd"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d1d4007fc91259ae1c04cba5ee050760e5cb6ba56acf50858843eaddccff99df"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "7c8b8550b11227b49f701949be909b236fd1c086538cc23b5a34c73ba4a3c47c23d76bbfb5fe0f97356b47af6d5295368594b21fffcbeee149d89d7e65d630c7"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "a94866bd3a1323bc4467de079ced7f942d9bf8ea247b82e3e99031a95460547cf0802aedf9c2e5b3d1a5128dc066c872"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "aa877b32fcb73f14d3d59da284182aa9638e6072608b4c8cbf218c9543fe3a63ee17089fb6b2537589059310079eca35"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "8ad53a2485bbdc7f390d59af49b5041cc215d12cdbdb9e1fdfcf102de41bd93b"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "2a81fe1dcc695c06542fafd2f458259e508c67547eb08ebbc5c11947845840706fc1f70d22aacdc90bc5e35a185bc52fdcd1eb4727a6bf12643505f5f2027e6f"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.james/apache-mime4j-core@0.8.8?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://james.apache.org/mime4j/apache-mime4j-core"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "http://issues.apache.org/jira/browse/MIME4J"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://mail-archives.apache.org/mod_mbox/www-announce/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://git-wip-us.apache.org/repos/asf/james-mime4j.git/apache-mime4j-core"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.james/apache-mime4j-core@0.8.8?type=jar"
+    },
+    {
+      "publisher" : "The Apache Software Foundation",
+      "group" : "commons-io",
+      "name" : "commons-io",
+      "version" : "2.11.0",
+      "description" : "The Apache Commons IO library contains utility classes, stream implementations, file filters, file comparators, endian transformation classes, and much more.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "3b4b7ccfaeceeac240b804839ee1a1ca"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a2503f302b11ebde7ebc3df41daebe0e4eea3689"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "961b2f6d87dbacc5d54abf45ab7a6e2495f89b75598962d8c723cea9bc210908"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "5bd78eed456ede30119319c5bed8e3e4c443b6fd7bdb3a7a5686647bd83094d0c3e2832a7575cfb60e4ef25f08106b93476939d3adcfecf5533cc030b3039e10"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "114f1e324d90ad887c177876d410f5787a8e8da6c48d4b2862d365802c0efded3a88cb24046976bf6276cadad3712f0f"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "80288c03ad4d80d69f91d056ffc5570d49a9c76bf54ad2dff0121ecde26a560df76d05156f281f5c6db2a38ff07a873d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "5adfb5ccaf5f21a549422f426118a9542673926fcd18c68390cf813e791dcf6c"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "7573f47f0babb53cefdc7c2309a0b982d800139064537b0797da442853d081010ad7c3c74a500598a0f800639a5d540eca21963ea652c68613907059bd4278c2"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/commons-io/commons-io@2.11.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://commons.apache.org/proper/commons-io/"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://builds.apache.org/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.apache.org/jira/browse/IO"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://mail-archives.apache.org/mod_mbox/commons-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://gitbox.apache.org/repos/asf?p=commons-io.git"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/commons-io/commons-io@2.11.0?type=jar"
+    },
+    {
+      "publisher" : "ObjectWeb",
+      "group" : "org.ow2.asm",
+      "name" : "asm",
+      "version" : "5.0.4",
+      "description" : "A very small and fast Java bytecode manipulation framework",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "c8a73cdfdf802ab0220c860d590d0f84"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "0da08b8cce7bbf903602a25a3a163ae252435795"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "896618ed8ae62702521a78bc7be42b7c491a08e6920a15f89a3ecdec31e9a220"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "afee8f98ee21771f104318d95b839d9ea6ea083157bd62d8bc3462d9302dc20ea939d1b4ae2222f92f09b92bc9ab1317aff02734007f716cc805fe49b92a8a5a"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "84f68859e74fc5a1bbb32bad682b3554ba0b4177f1e152991defe37151bdc31c1378da2876fe995c19445ca793260170"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "e2208311fb6a0807a535d18f7053c66b006bad3ff47c0937b675131d667b243402f8a4ed79028f24482f4c2d542685a2"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "ad3bf09396094a4522742f61155d40953b7c0ff806942e827797a1bcab62a8cd"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "37ac38d0cbaf89113e53845fc73da643fec6a2a6a4a0c03106b7c3bf2c645744095762d9b20bcaf5b691c3d91175983ad8e915d40ce71cdb8feae0c2bce17fc8"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-4-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.ow2.asm/asm@5.0.4?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://asm.objectweb.org/asm/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "http://repository.ow2.org/nexus/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "http://forge.objectweb.org/tracker/?group_id=23"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://www.objectweb.org/wws/arc/asm"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://svn.forge.objectweb.org/cgi-bin/viewcvs.cgi/asm/trunk/asm/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.ow2.asm/asm@5.0.4?type=jar"
+    },
+    {
+      "group" : "org.codehaus.jettison",
+      "name" : "jettison",
+      "version" : "1.5.0",
+      "description" : "A StAX implementation for JSON.",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "28a8fea7537770dd33370afbb942368c"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "933c7df7a4b78c9a9322f431014ea699b1fc0cc0"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "bbe6b18f6b2b3e9b7737fd6cc4e24119dddace93831f8635c39e65cf762885fa"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "0f342512ed3e42baf3cc990b498ee1001ed927c874fa5f51c551b39277e49be3aded727c872f9904d500a310df0182aa94f4fc88ad641a79350448b542275dc9"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "a63ae5992fc6d42106df626dd4c9f560fa00730f9bd2d78f7a62757ed4a8e0418da8bf7a404a3f033f966243e9da3ca4"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "c114c1ee17d537249f6a143c1939f21c69b990e08dfdc68ef40b9f79963771203d38cf72214aa4356ac1ca3146670d6c"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "d701f0eb8ca1fd19975de409ec503601d6cad33c6dadbee8a0360ab31d800bfe"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "6cd8ed3a7f69fb181b8a5b3a0de5a4217cf94d0ee1da51f16a64637d194e8d3a9263f129d5cce0eb66a3c8bb9ade0e21cf99d269332ee2fec476de449ca99ced"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.codehaus.jettison/jettison@1.5.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/jettison-json/jettison"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/jettison-json/jettison"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.codehaus.jettison/jettison@1.5.0?type=jar"
+    },
+    {
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-webmvc",
+      "version" : "6.0.6",
+      "description" : "Spring Web MVC",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "a9490ff83c795cd65753878f804e5fcb"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "302580efc981ad6797a85814ea0996e2149bb420"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "0bce2ff0e014e040aa1ddbed73c8ebc18c62e135852a70768353d6365dd03c1d"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "960dc307659469626698e0c4b334ef3215a786a941b330a1f82737d92bd92ed0b25e92cacb0dafd0a3fdb4a8edabe33e18233b6a8054b397d46f44c80e9e36f3"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "497cd6e9b249655bae3d63e36eedd6d6d763d50e38f3ccb422cec4ec2a7833a9cdebd2b18b0e95f6684b187efcedf0ef"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "5b1e009b54f07b77a1cc65b3b3710892ee506d91f6b18053855d8b3dce9a9489674ae5d5bfe4c5efd13d6e24cd45fff0"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "0858a624f3990da3f398c5774e4a5d58ea9205ceeb811d7f78ad39d8ca97ab19"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "69ee5d46165c2c6cf1265345b0982d16232b62ebb35b9e99059db9a0065fd344eea29c16e4564f775d510917107053fc24f274073238814cf4fba777db6044c0"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-webmvc@6.0.6?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-webmvc@6.0.6?type=jar"
+    },
+    {
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-aop",
+      "version" : "5.2.10.RELEASE",
+      "description" : "Spring AOP",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "b7cd197b841e02325420c6fd7c69cafe"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "b875a6bce7b6b0040816f1fb945f5fd9557e1205"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "7f89b3b47f686162a0948cba75a7862c4ffe713c76d09e29d470365f5fffdf54"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "17dba2ea95fe640ab425b10c59051c9f99b4b92f29c9b161902f091f45b763623d9dc1a72fd5e2205803a5ff3d30b05d93d07ad0c54854fc14e543df080e5d14"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "602f0180ca8c825189ec8206fd675dabed85b1d6f47a0f74eedc83e3a619a26e8e66a83104537c88e1e83d80bbbb2ac6"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "55c9f5548835ad402fb531a7b27e68d6b0ca3ac9e6f9155c230016dc2402be924e9f8930a7e855b6bff03ebda0a248f6"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "6544f822c31d4b51735b63791a6f79f2bb8b36c6d0661fbacd9531b6b8f1a12d"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "69620f2a5001fcab0c9567464efde1884c05b114e40c11aec0dea9c0d4087a925d6efb76ba98a8aaefcd163dad52e6be50bfbdbfb50f43fe45bf1b5324f63749"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-aop@5.2.10.RELEASE?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-aop@5.2.10.RELEASE?type=jar"
+    },
+    {
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-beans",
+      "version" : "5.2.10.RELEASE",
+      "description" : "Spring Beans",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "231f3af76e892a88bdbc5dafb69f58ad"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "88d4eb1380940163b7cbfe1f991158f4a4cd7058"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "f26ed1a9b3de49467948a9b5ca4e7a973a064bc27430fd1b419f075683cc08be"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "b0fa39061d41fdc1ce3ec643994475780b88cb31521525c676cced30681267407d676765cd14d9f26b869210d0d828f5db65a9e0dfaffd9118c17615472fe312"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "c3b4a4f9bfcedb577ad05ae8d84e03c50708ef28a4f4b21bdf897d1b63d37d0d3db7e41bb3a34dfb786d9962124a4103"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "6938b003f8b8234a83b8af10cb858997331577933908d01976d056c9da808e0b0af2255d66813644d5533d6288bfecf1"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "eb0a87da81f77ebfb7342e2a7cba187f0f85cb0fd121372dd983fcaf838d1b53"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "e7ff94c96b00160a25974cc584c9a8cff7246238c2c5d85f547fb8ceffdbd26717640df25bd80f601f7521eafb995951e97a0444a980cbf3a7283d9709c7379a"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE?type=jar"
+    },
+    {
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-context",
+      "version" : "5.2.10.RELEASE",
+      "description" : "Spring Context",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "2d65d5180c20371f8b7039a668a6e693"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "e43d1bb3b7387eebba96c00a63da8116f76e9426"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "00530d9627afb91647532df088cd90f00889a96172991316cc7593741d41202d"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "977ac91f07ee970145bde15957856497c145dd234c1e800bbb36bb0a7fff7238cf18fa77f3a3ce689ba9d68250af5a8c3aa5b79ff09d0918f1cdc128f972e606"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "edcea86e130127078a632da702a42f0091c9cd70c67c4376a750fb825ec53f9cc248c479a3419c892057f01decc56591"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "773874b6680c637484bc2b5dfbead5e07a7a669aeb791c4bc52540d37745f0c893c5e308a80802037221c06a5f31c0aa"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "89661ac9b8c4879c59812cbaf1b11cf6f5f00ffd2fea6fd2e392d879150262c7"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "47356e2dfc4d6e52b1ef05f7b8ffc625c237a7cc758a67aa7e92ad80c9459662e2235e6f5ffa41ccfffc05d77ea601e5b5187e4a9b1f306eebbc6e576904fa07"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-context@5.2.10.RELEASE?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-context@5.2.10.RELEASE?type=jar"
+    },
+    {
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-core",
+      "version" : "5.2.10.RELEASE",
+      "description" : "Spring Core",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "3d0d5f926f389f804716d8290e353604"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "29423e9f1d766eb4f4e3516211877f361fe3169f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "21b31ee8b896f1f79c92bbe8e2e30a25f7020fd63957416d28b035d524c632dc"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "403d51e7e096ee09aa1c74d8d6795a3b8a272ba9a5626a473fb978596d7c10e48302914ffa488b8f683f563802849f3a85186de148c56a0fe67b8afde76f9c2a"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "850dfafbf34bf0764bf3e5ea7ef68546ae9339032bcbdff8d59c2cbd2dd702d9a9d1ef8debc6f36a746052fcd4255c21"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "5cda0f5784752bc3e9720e378f4d449a25710e8e892bc810d080de32cb57e4fdadb4e36660ae73bb0a33240cef1817c5"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "aae97c5d513e6fe8f71758b203459a58259c3f5e8a0e615b815da638a3b41495"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "abae44d3d26376c5789c4501fe76d4cb196e8d97079639111cc928ae3dc4d2810981b7afe3ef93747e202e6a0ab206af0c05d2a21d4c9a28b1cbf99b564143a1"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE?type=jar"
+    },
+    {
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-jcl",
+      "version" : "5.2.10.RELEASE",
+      "description" : "Spring Commons Logging Bridge",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "5d06c0fe1f8cbf19ac5f566811100bf7"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "1cd2f1347ce808fe3564b7600e5f89ae2f42024e"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "148c22989b3f0a131b11065f044c4066bb92c898822f84b5cce1a24c8d2061ca"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "2267d7a1e3ad996cf7fdafe8142558ad2f0588d844fc0e5655c4b34e0eb00e375a0b3099346d3b89b3c338d1d9fca83c24f0d2fb07af170e0e5c281237ed37bd"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "f60c14c99d0298847b29ac644779a433a852106cdd130257d9cd53bca5249c5790cd006a8349cec47e73b0fdeaace633"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "dbbba58c787d4a93eae0aaf83c3dc63b53735c7a0700ba65d43c812d132d81450eb44c122dfe4b2272fe5b951599c5b9"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "85906d646d382c44c3fda9e931cf59d613b753b661904e7adea3cffbbcca398d"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "f4c40cbdbf9522b4c79fe506d9ca9955c86298fae0618e0fb6b2ed213006456b8727f55d5f0bbcb321ac04a8d3a02d53285fc70cb8fba7431bcc38a1bbade7f8"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-jcl@5.2.10.RELEASE?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-jcl@5.2.10.RELEASE?type=jar"
+    },
+    {
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-web",
+      "version" : "5.2.10.RELEASE",
+      "description" : "Spring Web",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "7df319c207026754c1664c37b806895d"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "7b494eab9ea8103d79813768fe4b7e7ac6d5e4b0"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "e7c4a9684a33d0af839157d20a1238e80b512eb4d4b597d9a3ff3a44763e52d5"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "4c4ac0e1a4ffad49285e609a7b4e37b293397a0a0a940dad5d8baf1a662f9f77a393abd824260a1c4269fb3b638ff80ba9d469da3c21be8d84702960085afd0d"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "45f3b7b18da5abb85c42976aff66428725d9afd977fcec85ebc4577435279acdd884f43f57eae73a49aac4fa1edd4abb"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "1304ba907b3ef4629496e8ff4f65f766272f6a09ca8277df041395e5a214efe027f9acad76d2315136d92df16d36b166"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "9c271e3c1315b1ae5d4b9b85ec1997235e3f3e8034361f3ebeb7eaf72f708a4e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "9f285504d076336be054c6fa54ee92f57614c99268ac57e7e19b96811008b60cb6ddcfc4f07811316b0ef6eb61bae57063c3b4537123b7e6b2c79f5ff68f585c"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-web@5.2.10.RELEASE?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-web@5.2.10.RELEASE?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "org.keycloak",
+      "name" : "keycloak-core",
+      "version" : "16.1.0",
+      "description" : "",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "039c47488747045a647615d84f200c3a"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "66ba08d3db5f346871a16f48708e0442812401e0"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "2b49cc144669a7c38637b6986ebad4697af2573ca796367967325d365756498b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "854e9a710ad8c14c59a1e4387dc747a68c5e2f80e49cd23fe6229544eef788687747bbdd51569f25841657d8c7107ad3d760aea00e07d10e2fece6be67280aa5"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "7ac9298265d5aef41e5a9e14facf1a60567bfaf943ff22457a3c8fb6916d8ba87a502a60001e522959a88698a007e353"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "bb37264ee8d5aca7724e93470fae17eedd13cce9abb0c419c4875e13b2d1809c32a4f72495f7fe57503cd6e7905d7cc5"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "6ae5cabc5cef9dafbb250225768f8822bbcefce2e6638ee05ab867e7aa06d792"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "76389a64ea40aee1c901f58b210a4770d9b352d3c3479d787d18da24f579437a3f07ed453e4215872956162bafa2df182a3d9325222539aa47a7d5ebfc8e981d"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.keycloak/keycloak-core@16.1.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://keycloak.org/keycloak-core"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/keycloak/keycloak/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/keycloak/keycloak/tree/master/keycloak-core/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.keycloak/keycloak-core@16.1.0?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "org.keycloak",
+      "name" : "keycloak-common",
+      "version" : "16.1.0",
+      "description" : "Common library and dependencies shared with server and all adapters",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "80c40674b8966a8ba125c05fc7d99faf"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "b4a4dbe289c6fa5b0186eac6249d2b03eef3f391"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d8bd0805ec13b716478ac6cb9b5fc2fee920fc428beaf85e20a9c98e824d32d6"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "343d364330c604e58838123e8e1fc3d69c6f07f15f8995dc306647b8a008337cda13ce11a10d3c94c723bc98a91b1deeeebcb793f8610dd80ebeedbd87906a88"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "dbb1df778c8246e60219feb1c1e754aadb85fa4951a94215d9faa2f65d026a98715c76068525f7efb1758dfea0462e2c"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "5f871fdc6c3cffa35f188200cae77d9395874f53e3b9fdb9614f419207953211b6895aa45d25ecdb35243d8462f2a579"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "77161671299322fb8604c1201cb6135d4a9cdfe30c8674979d8f7ac1cd5f3c46"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "14293f4b99b1c0ca38073754224e62578baf88190c6178dc07e2dc05877a0e667cb476381055090d8ee20fa584d926015fb78665325e5d6ef3d8ab5ae8eb30ab"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.keycloak/keycloak-common@16.1.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://keycloak.org/keycloak-common"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/keycloak/keycloak/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/keycloak/keycloak/tree/master/keycloak-common/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.keycloak/keycloak-common@16.1.0?type=jar"
+    },
+    {
+      "group" : "org.bouncycastle",
+      "name" : "bcpkix-jdk15on",
+      "version" : "1.68",
+      "description" : "The Bouncy Castle Java APIs for CMS, PKCS, EAC, TSP, CMP, CRMF, OCSP, and certificate generation. This jar contains APIs for JDK 1.5 and up. The APIs can be used in conjunction with a JCE/JCA provider such as the one provided with the Bouncy Castle Cryptography APIs.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "37e058210e056a04d4521d8185fb0051"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "81da950604ff0b2652348cbd2b48fde46ced9867"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "fb8d0f8f673ad6e16c604732093d7aa31b26ff4e0bd9cae1d7f99984c06b8a0f"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "1d18b43537370e0c7eb29332c9f9a4f0162f9bf68a79d6df3fb76080a8b96e1e378537e5a7aff481f2e1390cf45558b18679a1557ffd3c3b670b7ba1d625e8dd"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "964091a9942de802ef279f650e07bdd9ec116eaf5eaf5f8e4f616e54fc48437ef0ff4d1401361d2644c05b4c2d6c31df"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "07d80d3c005003db33c466c0c85fd40dce451536845f7ed781ad0a30cc88c9ca13124af6568cd7d7cc4d554a1c984997"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "2440b5f60bc8015d6203d57dd0a31545f7650165064e5c78bad4c21af286fec6"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "bd8ad0d429602bb75826e9a1918efeae9055ecddd114e82f9224f00dfc7664a72da58f5167c5abf29f3df46b11489dc3de209480bee62a47495554c7e80f9c4f"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "Bouncy Castle Licence",
+            "url" : "http://www.bouncycastle.org/licence.html"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.bouncycastle/bcpkix-jdk15on@1.68?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.bouncycastle.org/java.html"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/bcgit/bc-java/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/bcgit/bc-java"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.bouncycastle/bcpkix-jdk15on@1.68?type=jar"
+    },
+    {
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.core",
+      "name" : "jackson-core",
+      "version" : "2.11.3",
+      "description" : "Core Jackson processing abstractions (aka Streaming API), implementation for JSON",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "c78370567df0f7b95512dc7bc82bcd76"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "c2351800432bdbdd8284c3f5a7f0782a352aa84a"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "78cd0a6b936232e06dd3e38da8a0345348a09cd1ff9c4d844c6ee72c75cfc402"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "795e88d1d5ee0f4bbaf0049df2d3fad76e8bcb72c4cadd5bc8d2267d91d9d15c5ae1742e8d629adc2245a8b47ad65db9cc4e48d9392dfb5aa2087ba595d70f02"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "69ae1cc90b135a964d82d19bc7431e127f3f1e1a4709b7a4a5d1561a11f5e23301c6c2ca32838e0966c8bb3a807e8a85"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "c553372857c064d9320b32756e5eb4c91bfdfc6ff2deed8f6164621acd772e5905a88daad40a21b85fc14cf0e2421569"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "4d7958eb506ce19172a4ffb476b13dc4002b7df91b6358d0d4a55db937cb0f98"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "25cf3da77262782ce98b8ce3a49340de617bcb2815eb6bad221573d744bff213edff7198bcb8235c93d3ab8324ecf0d6255d091b47919148d988e8f8adcb6c86"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/FasterXML/jackson-core"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/jackson-core/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/FasterXML/jackson-core"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3?type=jar"
+    },
+    {
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.core",
+      "name" : "jackson-databind",
+      "version" : "2.11.3",
+      "description" : "General data-binding functionality for Jackson: works on core streaming API",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "52a89b1c5bed67972c82f16ba8163570"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "4f7b27416934dc929bb6c2d2c5fe521829e6a4ec"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "5eb2fa8403a077a15391b80f43784fe09f8787863f5c6f53cc9edd710fd3c1ae"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "51e3965658131706d1f562857d1c33a63b3c2b8e0587afa30c8d8da41664abc1bf96fe439d466847d061a168617fbfbec0bde0ea8ece7a7efc5a786bfe3d30f8"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "95f22600f63ddfe48a7550cef90aa4ec13718e983a397d29766b74ba2fe58d676d547cf667ec9ed73f5e7a838f471f18"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "b2e3bf887269a12e901fe19a214aceb51e8ccd39b1ecc3c125ccd9f6ed98a451f1f8895b78cbd970dc8913997bd136b0"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "112454b7ba18c7c41d549abcef1e4793f56a69b0e862bbd588abd669a6070064"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "c9faa94c9bae7f34599900f0677961332d6b12d55d3169c3f1c95ef721dd4e4ab80017dc29e774cb44f48ab6462256c6501045d41f27b055ea016e647d6b8f0d"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.11.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://github.com/FasterXML/jackson"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/jackson-databind/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/FasterXML/jackson-databind"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.11.3?type=jar"
+    },
+    {
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.core",
+      "name" : "jackson-annotations",
+      "version" : "2.11.3",
+      "description" : "Core annotations used for value types, used by Jackson data binding package.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "be88977d6186acca8152cf3f6ea798cc"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "25d4e9c777e7a8805c4a000a8629d3009c779c9b"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "6519b3811cb1c0afbbdab74fd841b0b34f3a489fccb43e9f981da1328d8ec23d"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "fc5443ce45dae4c955b6aa5be1f5fba93d4fff918aafef2b7addd754be9d0d4d9fdf22d9b8d39a53c3494feceddcf9468adcc948195f4e51960dc1635ca1597c"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "d962e2eabe5e202ffc4019a417750bc149043b11a0d9389f26d70988faeba1f726669a24a96c7ac87de8adaa67479134"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "c672b151d25b46d77c378368089c41bdcc9b8920b3a94babce3184a4a65b16ab228686a495821794c36ade941373730c"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "c450b925ca02af24025e05d1f7f74c7902445f180de25376d35a6096452b8a8c"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "28c142bf11800b8d7553ebc9d53717785a2a208f0a7a213099d92e38a899423bf405e0e770f2e89dcdb53227645f9abf23118ebaea0f31cb884ddd0fb643e73c"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.11.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://github.com/FasterXML/jackson"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/jackson-annotations/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/FasterXML/jackson-annotations"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.11.3?type=jar"
+    },
+    {
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-expression",
+      "version" : "6.0.6",
+      "description" : "Spring Expression Language (SpEL)",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "f632097b1c6f4d642dff5d7b7035acfc"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "2006ee0e1be8380f05c29deb52a97d3a1e6812d7"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "724e3d302c95de539178eb9e9a2ef13583fee51494babc93584ffe0a02e0875d"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "cef34f53ba19e71db433e8fc2940065a9a09f31b73783277638b196964f701cb5405b8d2d31be3e62be6a16e705d4bc02f1f78cfb1c37c1a52e63df6a793154b"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "bf8f07e7a861ce5f6bd782864e70ad7f0763282ef190d977881a1b5f573e55d9f9f8370106c4e3ba9c8d684e4edd50dd"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "948e7f1647c5b19cca32d5563dc4b33fab5bbf782908a34ac5cafc61fb2e5723515f116c13fcfb847becc4884b971ffe"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "1be82ca1bed5ca5664a074a0ed1c2409869cc26345681311344ec7fbac9e243c"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "c5e5c9e60fa4580f93168f48d238f8e4af68394d9d06374dcc3209713d781ff7f9193dfd69d1f8f1feb7f91523def9a24479232e7d59645689848468ac14605a"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-expression@6.0.6?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-expression@6.0.6?type=jar"
+    },
+    {
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.security",
+      "name" : "spring-security-web",
+      "version" : "5.7.3",
+      "description" : "Spring Security",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "3a964cece0dedfe191362adc3533d230"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "293cba5503450553600e3204a98241160ec95c1d"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "5b17c9cb0b1a332eaa14226f18f3611fdbe133e7e5f5aad82e9df767c612589b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "226e79810c5344dd3a2bb3ab575838cc245e22735307936986a547632c3305a623b2bac9ae7d91d31a0bae1b249cc6d055923bce33e1bad1424ca7670b23b19d"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "a2f993b39c57c21a82161682a5f1ea8aa584075d497f8cf7da72c1e3571c06b269421f35962a0d0a2be22c81191e3aa3"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "474e1ec7a1ad4c9b387006dbf495f9abf601702f7f63be6d3142a3758d10e4e6947d4d46a3e3e5faed70a0e0765810e3"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "15663fc2cd9a0c86f46606ab141dec908984276c2d818505d58b1411f1516bb7"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "9ceeb4e570febc4cfcd05620060b0c20865a14acb5f98eef062f7a80d53b5d2a7676a0b5b9b4540fbd6cb11d4b8fedf63610c36ceb1fb64e5ae53b6783e0a4ed"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.security/spring-security-web@5.7.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-security"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-security/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-security"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.security/spring-security-web@5.7.3?type=jar"
+    },
+    {
+      "publisher" : "spring.io",
+      "group" : "org.springframework.security",
+      "name" : "spring-security-core",
+      "version" : "5.3.5.RELEASE",
+      "description" : "spring-security-core",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "0198cf87d1656d21d3fdadf924efe066"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "712684f6fa4ff94c8cf59591918b06a260ae1c54"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "0cd0b6586d466b38d0d844a76032de6f801b34b6dfd4ddb1f4bde4b5abe3d995"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "dd5f2b6d157b9e299ba5488841cfd2c083c7bd82d04938c09a39036a7b41fcd45778140b54c500e7a307a06aef7c7342fffe5935a7d96f9ada436068153c2e0b"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "e1b321c7ae7b1951dab9ea917164958b039b53451db7b00d0c8c1f0c61224c1556d24feacb258592d324a71af77662ea"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "2c5b41df0814c8f997281208200531a431ee6ec48050f98933a159c1179bf3870964700c61f27981acde2be54c907e86"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "639f4880d170040cc56776d2b7a40c40d8f8d7a704182dfbf914d35f69507770"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "cd02270c737f4c0b0c9e7b16440815e687e6b21b4f6ac1e412a564fe3661003015de871a82e2e8304759906cb72d0c6eb5f2a976b9ac7bfedc8090aac6ec4774"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.security/spring-security-core@5.3.5.RELEASE?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/spring-security"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-security"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.security/spring-security-core@5.3.5.RELEASE?type=jar"
+    },
+    {
+      "publisher" : "Oracle Corporation",
+      "group" : "com.mysql",
+      "name" : "mysql-connector-j",
+      "version" : "8.0.32",
+      "description" : "JDBC Type 4 driver for MySQL.",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "25bf3b3cd262065283962078dc82e99c"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "41ec3f8cdaccf6c46a47d7cd628eeb59a926d9d4"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "522329fe925980f02e5eb89b59d227245d345415ff0c08932a68c9765c13acc5"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "ca7894157bc91a5a9f46eac954795450a9565c7693391dc25c2ec7ac6c86a43e695e9a2a6a141c21c700611701543395b52ffb3b4f6b2dab613d9c3423a33dbd"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "f81474bd825d34c39eae6fa1a75183be4185537f3bd46bba9e090738469981694dde500f5ce878207ec531d71b221e15"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "74a05d2a2785137cfee2841380a6f549e37ef9eed97e4d0c17dc60b6d79508b02749a293619153e9a93b0d18fc789859"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "6231d6d5fe9ffc9c96ba19c2716ffbd5ce0c53df775d0971671b56c7d20c1305"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "6458d23a8ca2149287f750737f5287d0f1cf3773f4d7f037f41162e6de5608ad0a363d98edfef128ba008f5c720f5b94b949856f553e5af79e3d8b7f523a6eff"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "The GNU General Public License, v2 with Universal FOSS Exception, v1.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.mysql/mysql-connector-j@8.0.32?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://dev.mysql.com/doc/connector-j/en/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/mysql/mysql-connector-j"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.mysql/mysql-connector-j@8.0.32?type=jar"
+    },
+    {
+      "group" : "com.google.protobuf",
+      "name" : "protobuf-java",
+      "version" : "3.21.9",
+      "description" : "Core Protocol Buffers library. Protocol Buffers are a way of encoding structured data in an efficient yet extensible format.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "3b4b9fcc1feaaa49edf970fd4915a0dc"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "ed1240d9231044ce6ccf1978512f6e44416bb7e7"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "1b78b4a76a71512debfdff8f8fc5aef6bfd459f65758fecf7aff245e6e6301e4"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "17596641c4a9d1089b186f46f925bf94929f8150bb6a6a9856a9c60f35f0afa28d05672e0a13f48a62164733a5b616227a15e7555530609e15157ca641dc6277"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ca685ebd2bbeeebeb3d204081adaa69df713dea3f3bb0e68121504a70b1a8608a75ec519bd42f381e6f0d0c99870c88e"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "76b08f9dd58bd18ca01e39eb4d21ba2771ce7b2b724bcc38e53d3d02e11569b142311c208c476241e1be11c6b32b146a"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "d714e7337493707bf4ad7762cb44b1779faf8580bb3e015b6c79653f8210e388"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "f555897dc551560f2fc0d103af1e6e6eed4bcaa0e1a14cf9517d73116407b4e441397ed65101fa3d9cfc52d7a85a61429426c01f214bf3db37171eabbc0aeac3"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-3-Clause",
+            "url" : "https://opensource.org/licenses/BSD-3-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.google.protobuf/protobuf-java@3.21.9?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://developers.google.com/protocol-buffers/protobuf-java/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/protocolbuffers/protobuf/protobuf-java"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.google.protobuf/protobuf-java@3.21.9?type=jar"
+    },
+    {
+      "publisher" : "Eclipse",
+      "group" : "io.vertx",
+      "name" : "vertx-web",
+      "version" : "4.3.7",
+      "description" : "Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "557644c01b7cf457a96c7304fd7a0d28"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "53052f693c7d19b5ab2c08597996dd35d7e3050d"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "8a2cbc4aed728a02701c981d9eb758412ad7c08a57dc169c62ffcbf906a2eafe"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "5886b373b541df008f98d03f97da45c524655136b2e57c8f278a8322657e8cc2586004c2342ff728913de3a75872ce648a2e087daf3f3cce42d1a61c871b0d91"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "c0cbcc31d0e39848e32a69846b4bb16cede17b9f1e8b3e55d31d75b63a1617aa6749cb1123f763918f9d0cfc876e85ad"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "b6e1360679a1609cf094e48cee1371006e7f8222edbb873eb44e5aa3e49bcbb610dc07faa40d904d46e086920d852c49"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "0b0d40006c521bab215d29c713184180420e1bb2e8e22596e30c3807cb92a1aa"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "ec09c197f6af5d02e19087aebe55ec23801ab74d4932e37c17506d1e1f5c9268eed3b7d0a0cea7e96eb5e062221788a3754ab8a5604ec85a990c25e5d27e954e"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.vertx/vertx-web@4.3.7?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://nexus.sonatype.org/oss-repository-hosting.html/vertx-parent/vertx-ext/vertx-ext-parent/vertx-web-parent/vertx-web"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.vertx/vertx-web@4.3.7?type=jar"
+    },
+    {
+      "publisher" : "Eclipse",
+      "group" : "io.vertx",
+      "name" : "vertx-web-common",
+      "version" : "4.3.7",
+      "description" : "Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "70d50598f66493430daf9ccb85e489d7"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "76b12e2b58b790a2b99de7afc3fb81e9b948f60e"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "b1f999a608c78404734c606cb3c0a03ff7d3fa925640b340e3cd8ec955ab2c6d"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "b7839d32a69c7588e936e677485538983a88e4e094d3a92aa8c78d3fe23f8b942b04c6ee2bf67e6100f1beccd7b890caa820a049a424b8af1477e0d91f5eca48"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "3d1eeda4d8cf7b93a8b6d5bf233e9efbfde9c9bb3cc48b7fa0d10dfd9dd5d2c3b7769bec6f2b5333051ada0cc271e205"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "6b3b7330ae3cd4221c739b1825b0de75004f17bf4ee87d6d4d66cd71a2f9c0b19275425e5747e30a85b75ec02ffe25e7"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "6c7b2041e968580b1480d879ffb82fc209ef77eaf7a90e2253b51ca5ff56eb74"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "5e6337ce9ffd4d2704a2421f494e69ef1b77d8a8c63ca97028efdf8be87c4b87a687336ed554f7b7b1f3981ae958f3fcbaed51dbe0cf237507303627a0314677"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "EPL-1.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.vertx/vertx-web-common@4.3.7?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://nexus.sonatype.org/oss-repository-hosting.html/vertx-parent/vertx-ext/vertx-ext-parent/vertx-web-parent/vertx-web-common"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.vertx/vertx-web-common@4.3.7?type=jar"
+    },
+    {
+      "publisher" : "Eclipse",
+      "group" : "io.vertx",
+      "name" : "vertx-auth-common",
+      "version" : "4.3.7",
+      "description" : "Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "342d089abd11b210bdc1e194cdbca1b4"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "fbd16a0fad72279cf87bbec529ef60c533902c26"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "2e59bc51177888664f5b21c1e08eb4b06106713fdad9aa3b664c26d61bbf438b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "92795fee0c2b583aba382d1260fd93cf0418396ba15fe7914e6b9632cd2ef9d5ac5cd04afceeb2ec0cdafb35a1338e884d9a817873879dc992171d2dc52dc320"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "9be9db14d5b3b211e8ba9870ac238b7ce52816be6daaf6cd6a132a875da5dab88f346652d53592224477039ad570ca95"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "575048c29ac3d1aa917989bda116c83380b1b3292a53ac7326377ca4b474dfdf2f1953f531f41f5a91eacb7419821fb6"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "bf4bb847bb24a43e9684745e7da32073bdb9b4607237fb62245c2f8ca342b2e6"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "7b828e28b7162e00a28b7d928377a61643d90a2526cb7e8637d144dd0bf78f1068f4ec2fb61f470818d8e1d143705c93e025dd2cea92171ca61f410e16e7f0b2"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "EPL-1.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.vertx/vertx-auth-common@4.3.7?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://nexus.sonatype.org/oss-repository-hosting.html/vertx-parent/vertx-ext/vertx-ext-parent/vertx-auth/vertx-auth-common"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.vertx/vertx-auth-common@4.3.7?type=jar"
+    },
+    {
+      "publisher" : "Eclipse",
+      "group" : "io.vertx",
+      "name" : "vertx-bridge-common",
+      "version" : "4.3.7",
+      "description" : "Vert.x 3 eventbus bridge common configuration",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "5f6387be655317225cfca5c4fb47b7e2"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "be56d8de0fcb1ef30f0035b96bdc853f5da92468"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "ca0d1a96660ac3a8da2597f76e4dc1fb90903ffecc159e4bcd614a1238f4097d"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "3471c4fcb52bc1496689a60e5c2a90c6a1ead539e78064ffa2222db8c13f1cd44cfb0c61148156fe29d76f1d9afce1d0663d8088a2cce12d19961d622fc29f13"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "8f24357349b9f146d76a380af292a93031f5fbc21fd898c00c2a4b3d24856e61d134ba620b8b75d3f034d2baae3c4a75"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "f2336da9f422ccce19c22066f693f70f1601efea8f7d259b9efc6c6c07b19539def7c04fe26feb0bc69b4a87ba5bc443"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "58c1c8e800b79a371c5069d3394135bbc912370f146eef53a42b597831f14a26"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "749b5250b033951531b5888cfdefa3f458461eb57adb27928430c708d6d69cb5dc989531d9563044ae3de930a9067e28595b3bb7f21c7c9af0be82c6f5819ac8"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "EPL-1.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.vertx/vertx-bridge-common@4.3.7?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://nexus.sonatype.org/oss-repository-hosting.html/vertx-parent/vertx-ext/vertx-ext-parent/vertx-bridge-common"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.vertx/vertx-bridge-common@4.3.7?type=jar"
+    },
+    {
+      "publisher" : "Eclipse",
+      "group" : "io.vertx",
+      "name" : "vertx-core",
+      "version" : "4.3.7",
+      "description" : "Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "08a9afcf0db4ff8e65a81cd36d2cf0df"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "7d80441d7b57b7a66a9a2b67072186776e295eb3"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "80a7c7db6229cfd1581363e5aa44864d76b92eef8fc113b2d5169eceaf079b47"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "4ae6a321a125c60724654df5bad19f56b1e3d5c7b275a40d3cc0f851006ea9bdba64b20930ad51ffdf54027bd7555aa1b781af1c3099c452fe99eed31529dbc8"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "de4c9b3527931465d25306dc50ef73d8028bb2a74150d2a9b3f76df78b79d2a5de3f604852cfb6f0c6b226d24c146782"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "72126aba0d5c9041e63457aba96925d962b093e2e7a3a49c20d92481af6edd3a75047c9815f49d425a51dbd13acee216"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "32877565cb2dfdf2983cbc81a49e7d8c5aa8355729970fc1a93c9e0a19004b75"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "1d41ce2d5d8460523e624c5d07e8d16eb1695a12775c5a7ee06e3bd8be48d6ddd3da623978784f30fbb9567863d72f2e9cbd2edd0f7b9e280a9f1e95ef23cade"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.vertx/vertx-core@4.3.7?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://nexus.sonatype.org/oss-repository-hosting.html/vertx-parent/vertx-core"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.vertx/vertx-core@4.3.7?type=jar"
+    },
+    {
+      "publisher" : "The Netty Project",
+      "group" : "io.netty",
+      "name" : "netty-handler-proxy",
+      "version" : "4.1.53.Final",
+      "description" : "Netty is an asynchronous event-driven network application framework for rapid development of maintainable high performance protocol servers and clients.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "8dfb62443092593e32422dfd05ecbc37"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "24007d9b48de8694e62c0796e5e7bc51c1b0f369"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "1f4b5a540f596e45bcde7c53f4c02780aa5e56eea4103eee78b7d104f90c97b1"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "a5c745f898254d09d0b78985283e5af84eb80e3f6112b43dd01ef4686dce35c0596aa8f48e7b913bde0e2e6f3b314fe821b149c494e0036ec37d9bffd8a3ecce"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ed09093605b7119447e12ca4722802a2256a7c187e659442ae64e295b810770b070eabac41a3acde76c3bae337e6c918"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "dc732fd1925fca307c1152825a99267149a6fe6855578af3deb9b937770ff88d5403c6567ce01221f3ef2232db45419b"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "e46ff09f1ea5d02aa3df209903cf7ed7fbb7e6d228ab85329ba775e26b9102c0"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "e2e37b898108975a2971fe10855f1327a919ca797a4fd47d960bc99b2f6f7f55f3536258a83fda62d5d6a6de67109aa244a5042d2e3d51f894904b795b05ffff"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.netty/netty-handler-proxy@4.1.53.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://netty.io/netty-handler-proxy/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/netty/netty/netty-handler-proxy"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.netty/netty-handler-proxy@4.1.53.Final?type=jar"
+    },
+    {
+      "publisher" : "The Netty Project",
+      "group" : "io.netty",
+      "name" : "netty-codec-socks",
+      "version" : "4.1.53.Final",
+      "description" : "Netty is an asynchronous event-driven network application framework for rapid development of maintainable high performance protocol servers and clients.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "c247c8deda1e3fc12cc21e637fc60a4e"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "669ea5cd9137c57d5b2dd71b11ed59adf1d70f85"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "8de51d13f48da8eece7df43aa00d6d2923a215668526d8888879fa1534e9aafe"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "794cc5aad69cacbce3cce84785bdda829f03abc07e0bf8db2eb9e39487014414fc27195b1a5c917d27ecb5f64b24ed9f192ba717c24550c58b551948540d27cb"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "e19279703f9e246420743c64abf4acc8910aebbcd1a8596fcc81f8af4611c1c3a892b605743c4df98879f20acd09809b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "2b8547c658234dd3307dc1d728a86312f0e9440162da9b149cfe81b739693612ed9c69ee90ac7df82f49b1f36cf60354"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "09366b89108bf692422d86a9a7ac7548cdab4c90d6e54d2517ea49957e436c8b"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "dbdf4798de8713db36e871b0d965fa532dc6b520654242c4f893762c9f5394d20428e313598797c946c77c91c8cd16d77e8d2099c178a4185297f3dd75d7937c"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.netty/netty-codec-socks@4.1.53.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://netty.io/netty-codec-socks/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/netty/netty/netty-codec-socks"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.netty/netty-codec-socks@4.1.53.Final?type=jar"
+    },
+    {
+      "publisher" : "The Netty Project",
+      "group" : "io.netty",
+      "name" : "netty-resolver",
+      "version" : "4.1.53.Final",
+      "description" : "Netty is an asynchronous event-driven network application framework for rapid development of maintainable high performance protocol servers and clients.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "8ebfb30394e3088041124d6bbd2b38e9"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "fe243ee1fddf47e3d54ec83d9f42ef35bcb5ac3e"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "93a531bbaa6d3a0652cbc9f13c21ca6cab9d6160c7a6f47c9cf29a5f2c5d6489"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "a40de90a8367e632d08323998bcabda00e74a495a1e5632defbcb2673fec258336897738ed12d8bad87bc1c5b4df915b6fab0c1e89837f86138b806c5100134e"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "d03c1d9d4961e38299d690d2a9da31f934ea2ca622eb04e63d15fc84595ff499c813e7a12fd04a40291767b7e682ff49"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "3552b4d2679b0de2194de7fafa92954506661ba2152bda1ddcd362b7e7aeb9cc7aa71278ac8efb005a892282a1759168"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "fb1e56044ebd545bfd16a6f9fe20f7c3fbcdc82b1752ad43e3ebdb51a43affa0"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "52c58540443d9fd4dc8fe49ee580731a0ac7577b94fd557aa1595ce1fc89e42d9197fc10ff40ceea0a7475a55eb3780bb4d871ec059ce1a545b995fdf02be1a6"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.netty/netty-resolver@4.1.53.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://netty.io/netty-resolver/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/netty/netty/netty-resolver"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.netty/netty-resolver@4.1.53.Final?type=jar"
+    },
+    {
+      "publisher" : "The Netty Project",
+      "group" : "io.netty",
+      "name" : "netty-resolver-dns",
+      "version" : "4.1.53.Final",
+      "description" : "Netty is an asynchronous event-driven network application framework for rapid development of maintainable high performance protocol servers and clients.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "37fe373b85292b6b567f0b1d4207f4b6"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "73fd6fc1d9e8742b41a696cc5ef5525e190a1a24"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "bb63961902ce4a4724e80efde16a63b06f871a2cb2387eb90aa2c3663f17db90"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "03f9229b420f83dfe9ab1663901f00ecbb0555495b7865de61e5bbda6258dd811e20f198e6b29b862c556059e255a56d9e3d3a737350774268efc7351ae0c701"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "402d3b98f25ae2140cbf5897d822c44343031bb1ebee03c1c5c4d26a63f3e808dbfe0e10752db35ca8ef04b66f2869a7"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "a042be5eec6beeb972d774fd0b178fb537a905c9f0cda4efa59026654ee2babb5cfc771bca12aabc0e92cc85366949d5"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "afde01e5c8bf2f64a80bd235d53ce3e3784fb78f00a204398482d4eabdb03ceb"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "cea85e9380832b898e0bc4dcadb1fc73c77137e5fcad64bcc67cabc84704354be0ebde6ccb0801f963e0fdd8e2c8ac4b7ac4e139accbde868919e2388442de0b"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.netty/netty-resolver-dns@4.1.53.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://netty.io/netty-resolver-dns/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/netty/netty/netty-resolver-dns"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.netty/netty-resolver-dns@4.1.53.Final?type=jar"
+    },
+    {
+      "publisher" : "The Netty Project",
+      "group" : "io.netty",
+      "name" : "netty-codec-dns",
+      "version" : "4.1.53.Final",
+      "description" : "Netty is an asynchronous event-driven network application framework for rapid development of maintainable high performance protocol servers and clients.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "2fb31cc3a9bda8a40038dcadd8bebdc4"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "7d051b78643b035e0adf0bb2caec3c295b4972de"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "747098d17592d092afdfd8c746e099c3b739986461ebcfa68d782f4b5b19b8ae"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "618f2c51f6defbde9a7a30fd419d90e65461f73235b495dfa4c95b8099730ff2cd72e5e59acbb25b7d37792d4cb060c11729e70c7f4528e33ac87f071dfe6ca8"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "1dd0ddc4fd8782cc6583df228e4b589dab9024ae7e66c8df302b2f78ff9580053bf9cc57124efb418f057995d7fbec12"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "828e125dd7d87ffde8f5ebc95063da67645c5fdb47e1bdd1520746d113fbe48e52e7540f3a07ce7fc485272e84276c95"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "82550d72c3e0cb2778cfa6af7444abbdb10108f5f349fc46e8dba5f1df39717a"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "f6de6b55d2fa04cf05808016a7a337adee223183b772de72626e8f7a321562308798c63abe16cf873590872944d97cd8fe4a837864f696ddb34c82717cc90cf8"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.netty/netty-codec-dns@4.1.53.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://netty.io/netty-codec-dns/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/netty/netty/netty-codec-dns"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.netty/netty-codec-dns@4.1.53.Final?type=jar"
+    },
+    {
+      "publisher" : "The Apache Software Foundation",
+      "group" : "commons-fileupload",
+      "name" : "commons-fileupload",
+      "version" : "1.3",
+      "description" : "The FileUpload component provides a simple yet flexible means of adding support for multipart file upload functionality to servlets and web applications.",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "fd24e83d8f62085f84c0622087872f36"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "c89e540e4a12cb034fb973e12135839b5de9a87e"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "bcea3f830ff3867c6700c1fc12282c219ecf77ae6b36cea445b8e9dc751449fe"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "f9e2e5b6143d9063a484fb17d16b2bc80ae17850697ad8153e92fc57210ccd3cdeb5c8a7ea290c1c13700cf5460a84ecf40d1b3a20681af322bb2f609785dfca"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "5d2589c8b718cdd3603f9272ddd1f9e6a262fb0ee49b029c7768b89da7b9a1533f1fa828ab1c859369f4834950f35ee5"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "daa787fd8e5ba21a6685ef65568ac707a8accad4092b6d1ed22b2c0aec54f730b0e74ff16a8a69a9d6216038641fc936"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "d4aecf49be05b5303bf7ee6239560c78ad8efa8fc733cb5cc27c185c9a4b9211"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "bd50ea1f1cd7f93ea4047ff136b71062b315f699f24751add916325288124a19a2c7572ca454b02f08a04cfcbf1b50e628f91259eeee02b28c257d1172ccbae9"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/commons-fileupload/commons-fileupload@1.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://commons.apache.org/proper/commons-fileupload/"
+        },
+        {
+          "type" : "build-system",
+          "url" : "http://vmbuild.apache.org/continuum/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "http://issues.apache.org/jira/browse/FILEUPLOAD"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://mail-archives.apache.org/mod_mbox/commons-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://svn.apache.org/viewvc/commons/proper/fileupload/tags/FILEUPLOAD_1_3_RC2"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/commons-fileupload/commons-fileupload@1.3?type=jar"
+    },
+    {
+      "group" : "org.apache.tomcat",
+      "name" : "tomcat-util",
+      "version" : "10.1.7",
+      "description" : "Common code shared by multiple Tomcat components",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "bd09a592798af3023ee5f861d3dbb3f4"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "98ddf572a5600dcf2bbb04b5e9a39e8017934009"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "f7530a1122635d2ede75405de19d1cb87405e3d4469920cc657f9acb474d530f"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "0f2445c55842a603263ebc37c0568cb92aed01ab9c3854fc85ddfd72fcf4b2ff7bc9fb505bf60cd87ee054ea43baadf2c026ca93e392eb484feabf909c571598"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "555326261387ed137df3e429d28a04fb6404ddb2cd1a0042bbab83c238e5781b87dbf83bb136702888b14e52cf93d4d3"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "95c79288bd42035b8bb903eab7ad50b2fae72904713870dd329a35512711a764f8892c7d3090fb0807531f6db9137e96"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "1a70b15f8197a00201d937bb7b7074c63a93c85e1190ad1d691bfa41d33148b9"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "fc3ed4994180247de6b056fbfccf9a7db53707e6b5e20ef078353d3a1b1830cd7f0cd2777ec0056106d2c83c64278dbc3fd25e6ea09ad2394b6128315f7a60e8"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.tomcat/tomcat-util@10.1.7?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://tomcat.apache.org/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.tomcat/tomcat-util@10.1.7?type=jar"
+    },
+    {
+      "group" : "org.apache.tomcat",
+      "name" : "tomcat-juli",
+      "version" : "10.1.7",
+      "description" : "Tomcat Core Logging Package",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "9ea9c1a3dbdd78eff902b8fa4c858f74"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "6fa184da429fe8ea46b8d6f4a3c7955d914d76c5"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "81dcac12239a2d37feb7d57dfbd560652842b5864868f22caeecaa9838ddd8b2"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "39b67833243cd314d6815c3638c31d412ec91e22bd0ec392f3ce7532f25d74e17cdd1b9d1a6d573f10dce599a78e544af759a696f1d9d696216738d6259101d6"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "de169e951ee8ec6bcd34ff2f3c39516db5deb7b0aaee9a954fb94a985b245acdd859790a18286c04ff9c2e85dfec046e"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "0ead42578357aa110eebde7ed6277bd8c07cda1ea68954c5059f074bbeb0d2e35dd2acb80aecae8bbd8235bcc8d0d2eb"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "67b2a482c5fb65a325e978c15a8d4e5769fe628ed4c524c9fa383b3bab43580b"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "005730f6acfeab51745c591afb0f7bea6ebebaae0b7c3abc2dcaa162f98825bb2de77bde9de9a672afae934661531d79322e277071f7c5045b4f26e757150577"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.tomcat/tomcat-juli@10.1.7?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://tomcat.apache.org/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.tomcat/tomcat-juli@10.1.7?type=jar"
+    },
+    {
+      "group" : "org.apache.tomcat",
+      "name" : "tomcat-catalina",
+      "version" : "11.0.0-M10",
+      "description" : "Tomcat Servlet Engine Core Classes and Standard implementations",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "ec0414b1896d2e5cba0f932bb7cf68c6"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "978479c26840b4cacccd4231c14d9d88846abf64"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "656ea625c5e275b1ed9b158f499b4fb459b2143d78c08db0555910e4ba4de182"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "28712a9257c36b30b8e572adefa69a75bfa21feba5bed9cb5289db17b315a2db1fac80023b3d65b94096d850b153657810c0f6905df277c8f2c2ad788835651f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "5e6fbe1ccab942ec8b968190b9855946d080b88f37b1deba2e11f21e7df42696f469b1f2b71cc169fcff9119d13893c1"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "1dcd090afcd9a826ab8d0c75ed4d2908d6fb5b15be81ebe2ee3716de8982533429f8198201a623eec4d49fa0a13b91ec"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "528db8082cdd38726263490a72704bf36d547605cd91cefd85a16707e9cbca64"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "e93482ec1572e23b068f55239e3c1003ea58ea0ac344468496a0457ab3339ba698750ccd9e036049a7e6f4273a61e4d8d55a2d340b273ed1d4c38c7a39abd877"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.tomcat/tomcat-catalina@11.0.0-M10?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://tomcat.apache.org/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.tomcat/tomcat-catalina@11.0.0-M10?type=jar"
+    },
+    {
+      "group" : "org.apache.tomcat",
+      "name" : "tomcat-servlet-api",
+      "version" : "11.0.0-M10",
+      "description" : "jakarta.servlet package",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "a0ee135dc24e62a2cf76d3ae61b4484d"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "735f852293210585cfcb79dba91afb0688167218"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a295df133fe77db4db25b20b61bf81f5e8bdc5a9d696970dff660edf47e40600"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "5ebfbca31044c59a6734f7e3f8d0ad402efd66b0061a321ea53dea4b51c765c1553f2f0d19ae13d7e9c3f83bd0d39ba073df3279e6b3efada0e7a76db81486ec"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "98c59e8f9727694c056b0461b58e72751aed79785081be105b812917d22ec060127963efbe9fb730871d572d2ee11c67"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "41b9af6a6efcedd9dfb259278896511f4d587492aa456b290686ad30a6043a6fc456e75df280faa08ac91589775d6863"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "273f267eda2e085e223f24b7f4ac539ea31261cd9f539d5807152d9c85724763"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "bfcdee525c53ae8a166a10157fcd27b7ea1875487a9eba00ab0f9fe35f4168fd424f152948c0178ef2cbec0db4d7585466ac0a6b0dc89cfff9b118e17bf04269"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "Apache License, Version 2.0 and Common Development And Distribution License (CDDL) Version 1.0 and Eclipse Public License - v 2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.tomcat/tomcat-servlet-api@11.0.0-M10?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://tomcat.apache.org/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.tomcat/tomcat-servlet-api@11.0.0-M10?type=jar"
+    },
+    {
+      "group" : "org.apache.tomcat",
+      "name" : "tomcat-jsp-api",
+      "version" : "9.0.39",
+      "description" : "JSP package",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "6e0298331b92f426cd048a1b43a18fa1"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "5298881ff536bc59f5038db31eed51c3bc40375f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "ff5d850539b2e07735e9d91da467d4d88261a8f4cf2fa56fb950140c4fd8ad2a"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "d34deeecdecd59e40225ca3ad0ac197fc7f7845f09f551f5f17290ff9971741e62fac4bde16499d585b3d7c5574927c09740c0976dbddacecb19b4772f60c3e3"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "603ca3e1928a87b40df468cb046c8d6d0231cd02712dab54861583450ed37d5fea8a6aef32d4dec7392228dd09b7164f"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "45d93fd577494f51baa238bcd334d51d388fcabf40d560e29421c91066b2400703ea0a0ba818685c143a8a6a5aea7750"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "f90860d3e5416383e4d54f39cdcf0158157192da36bd691fd7e412cffcdc560c"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "07319100782a8c0dce938e7ee2387b13b1046cdc6b01a7caa7e787acc37c08c9dcf8d62abdaf8165addfa54848856d2cb96b32358c5fd21ea92d453cc515dd44"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.tomcat/tomcat-jsp-api@9.0.39?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://tomcat.apache.org/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.tomcat/tomcat-jsp-api@9.0.39?type=jar"
+    },
+    {
+      "group" : "org.apache.tomcat",
+      "name" : "tomcat-el-api",
+      "version" : "9.0.39",
+      "description" : "Expression language package",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "68f770c753231f11648886b67e9c391d"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "3ee577fbcb442898508bd0d084d37241eb2efa6b"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "fc965b181d8a3b67a8d048ce811560cef0655494a220b7b0ece6c29f09f801ef"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "661e613ae966e9b1fcc8815823c273fd7a05a6f8d3c469d86ce50650c1f350cbfb624fde8ee86235603078d9c5ccae5dfec8e03e10b5cb1e11109ae6ae4e85bb"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "6521d666a115b90df2fd3c8cd3d68d5a66854ce9a15a7519a9c4909a91382f4f6365ab9b238b9f5200cfaf7044cf61ea"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "2ef00ae440962726c8e4631b3fdd098cd0cbf22e87ec6b666f6a18a2ae5fb51d7bedf591747b09b220739ee0ccae0c3e"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "ce7a135409a622eae6240a7dcb10ae15500879a8a219d4b5d4dd9ef467ed252e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "608a64cda626cbc1d97f0b66618ddf2d6f81e4d588bf03e68f4557f9be34a9d47581b44ab451e6e4175dd4df30270bbe52aaec0769199817a980d47b3cdd7d26"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.tomcat/tomcat-el-api@9.0.39?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://tomcat.apache.org/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.tomcat/tomcat-el-api@9.0.39?type=jar"
+    },
+    {
+      "group" : "org.apache.tomcat",
+      "name" : "tomcat-annotations-api",
+      "version" : "9.0.39",
+      "description" : "Annotations Package",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "de1d58208bb5cd9c36cd72ab7d52b370"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "53d0991b26632c4eaa6c67bfba1a15ca7d929e11"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d74f5eebf2c8817ffbc5ef32f3e17e226e6cad163a26e035b943e210570df305"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "54f57dfac845d571ed6cd77ea60c159e523d0baec973d23a4bcd0a9b49e2c0a29a05dd5042b8fd44755b2773ddf8a270320c1a21c06785c3134521c28562225a"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "a80e76b89de59dd51d42ced38bff8711aa1fd2d5130189f9f8309b982f415be51f9fd137302e29f422f184f1c6c209f5"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "5590db29acafc71ba8b8b69891eab504157c982b3483589373d8e06e0c3681d6d4c16262fd0306571399a73853430f48"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "ef911bb90d351f4ee8887f16437e9cd1a7dd5870323d69623e5fe9bb9cb34813"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "cb6484c1acdac9c74f54c7be076b8eec7da3de0230f7f75365562ceff5c49564341c423e22ab6762ca5721e69ebb74953edb86d3eb3be86502c1638813823b55"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.tomcat/tomcat-annotations-api@9.0.39?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://tomcat.apache.org/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.tomcat/tomcat-annotations-api@9.0.39?type=jar"
+    },
+    {
+      "group" : "org.apache.tomcat",
+      "name" : "tomcat-api",
+      "version" : "11.0.0-M10",
+      "description" : "Definition of interfaces shared by Catalina and Jasper",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "de965aef8022a7aa92ed31c6126d7d5e"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "3688629d979878a13f996525cc1269206c5fb958"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "997d2827dae8c9c76cf5c0f2d826770982f6e960101d9322622eefcc15c1abbe"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "4235309c759f43f511d80706cf6124b99222642a2a2ce0fa17ccb5ccd8c02c9accab176d4905ed5c303f751c7bea78ad3d0fbb64e1aa37fe90cb6e5cb9a549be"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "c0a55ebb252509672b2e9a2e21a169aec0bec516798514da3c19fa5a7f0826182a8424f654f96432655e9e18eaeb3b56"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "55b53e91a14942001f0259b8c8742804e60223a6328c342382809188c89b152ac06f83421ddda002c0970e8ad176508b"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "74061d169dea615dd4bc189d32291f5f8b9ad93afe02e8127ab9032cacba103d"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "c7a41d5bbbb997fae4cd1c1d06d0515cb85e034a9d77a599503e4e0c1bc4047e3a1a7488e863af9480dfc79bd05190e8c66a68d5fba975a1ab75f1444f77a602"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.tomcat/tomcat-api@11.0.0-M10?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://tomcat.apache.org/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.tomcat/tomcat-api@11.0.0-M10?type=jar"
+    },
+    {
+      "group" : "org.apache.tomcat",
+      "name" : "tomcat-jni",
+      "version" : "11.0.0-M10",
+      "description" : "Interface code to the native connector",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "b64f49c79c5cf78bdc627a0820599424"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "16acb55c2117ae612fb345439c1fb5e15de2fd57"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "77ef8adfeee1facbb1fe4e91047e977709110e6d67784abe74f83126711185b3"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "5641be7b3f03c0e7334d3704b7059e2c1f1c0d69c1287e47b58da042b061a1d08a51046b07893a27becf90f1f9a8ef6ef2c7d7a64efc34b06d9dd02c857fb40d"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "338315644e3e8b35593921c4a81c7d79aee6bec8d7d4248bbda81750a711d969e90773eab7ff9f992c88f8d8995cfd6a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "d35f4135b47a05883a98dbcfc4c4b54ab99e07765d151b4387a60105c41f8e56e88279cf32dd2f972ab7aeda2f710b48"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "023d6b00455177d2c0e299dfa84c0bb56378ae4f4f98df1e55d624d9768272ac"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "80bccc74c458b61e09ba94b4deab7b64a492e517e1c136891cce6abffd275acd1fa215d34ab305202272bf1979b3f28ea4bd4333113e63bd0017b97fac0d2fd0"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.tomcat/tomcat-jni@11.0.0-M10?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://tomcat.apache.org/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.tomcat/tomcat-jni@11.0.0-M10?type=jar"
+    },
+    {
+      "group" : "org.apache.tomcat",
+      "name" : "tomcat-coyote",
+      "version" : "11.0.0-M10",
+      "description" : "Tomcat Connectors and HTTP parser",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e8ae218f480f7e7a0aa4c06ea63ff10a"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "40f045e5e444c503b2548350ec5a6a394ec5585a"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "66e7fce369678086933e001f980050a071e007e5c4865f725d79d8ba50404431"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "7fd986dc73adcc726e75f5c0a6da77b12f7cce4e9792393e92e3c8061275359409152a6e55d650948a51b622e7a56528e00a78fda3f95655b50b0d669640ac81"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "19661ae732e42139109add2aa87990eb55521130c70a7e3fd7c0e0d2dda62cfe993aba99c075b293a8a5a3431ad74ac9"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "a536df511bedbac079a2419165c3fb99e0fdaf6ccdbfd602961a873f9e0247e14188bfba05a4689120a0ac20c6216ac4"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "584cf55a72de73d9c8acfa20ff4122845e671b8890471bc6897dc03be68c2912"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b5c767929f42795a362797ee0a8b4a4a7fa6f9d40b9cf5c4eed1474811790189f7dceda1a8f808933c81ef264c4b1e92b99ebf9675d662c9eab52cf659911fe6"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.tomcat/tomcat-coyote@11.0.0-M10?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://tomcat.apache.org/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.tomcat/tomcat-coyote@11.0.0-M10?type=jar"
+    },
+    {
+      "group" : "org.apache.tomcat",
+      "name" : "tomcat-util-scan",
+      "version" : "11.0.0-M10",
+      "description" : "Common code shared by Catalina and Jasper for scanning JARS and processing XML descriptors",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "dc179fff449d2f1411efd950cfc85422"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "6cc4126a00b1e6313ab0f4e8f7e873f146338041"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "dcbe3c45fb7e6107b1724d461a2da98703aa8f6b80bbf1afe91dad5729b3d983"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "6cac59856acc2b1c16db3a78c84c8819fa3a09cb6b60103b974f2b5ce137ffb8099c8ac88481e391e379601cafa89ad34a74eab41579d840127b60ef62bcd67f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "b971e8ae345860112398392f6f162f97374966a150c9eec9346527bf38888feaf1282fb3fdefc4db6e3d75cf234b809f"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "de28595d3e1ae671f5b5670900b3a53f0b89873d0ab5be9935e9fc043ad975439d8555685b1af334b57e51db38742897"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "97e9afab15ee4aa0d6f199012f745e47cbd0ad391e2dac14d5ed4abe45508f95"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "c96d445f9772b3240a6dcbfbaee149632b861c25d3ed7edef984cc90b8fbbfe05f56396478facc0684376517b63a384164287ce446de11210c0821d01a4a55a8"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.tomcat/tomcat-util-scan@11.0.0-M10?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://tomcat.apache.org/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.tomcat/tomcat-util-scan@11.0.0-M10?type=jar"
+    },
+    {
+      "group" : "org.apache.tomcat",
+      "name" : "tomcat-jaspic-api",
+      "version" : "11.0.0-M10",
+      "description" : "jakarta.security.auth.message package",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "3e5e54d29d1cc670e7371684abf38e1f"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "d5417e1859db4842ea5b8261625c48360f506c41"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a7c6cb07c209929f19c732ccfb1081d5d3dd0547e3c5c0f7d6ef69422a696054"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "441acee52f7f8f020d39c57677b7dc872119d5ab9a02f2deb2a0604e729907a6e163540ba3308562c0a31862652e39cd9d710494205f9edc035e8b988abdc793"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "91ce560a833d9f2aac80f6706d18b53bf73b96fff75cce6abb9b102b02c526f31932a55bec5503d4999fa726df802947"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "d00003ee8634f0635bfbbddd3712fb4a2ac4c96b05c3f99c82267ad2ba40796fa4b58f002e2a54a4fdb0f837e85435dd"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "23c7d402937b1dcf2ae9c6c9751c0c5696c646ca7ec4bd163c436113fdca637e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "87b1ade0b5ff56aab10f2a811987e1e9dd5ee65a505f2d00be6e99a6a4d38253eb35f0305d8e4b0ae7479d38b04a9317826c5ffe81fbaa6f561a4d3c0711e9b4"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.tomcat/tomcat-jaspic-api@11.0.0-M10?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://tomcat.apache.org/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.tomcat/tomcat-jaspic-api@11.0.0-M10?type=jar"
+    },
+    {
+      "group" : "org.apache.tomcat.embed",
+      "name" : "tomcat-embed-core",
+      "version" : "10.1.0",
+      "description" : "Core Tomcat implementation",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "63921232774e8925bdc8981e08fa3e75"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "d1feb9f90a805b29e96a795fc672691637d16040"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "e65af57b06045a0e41c6436d0c1b6d3c13f32dbdf7df2e44e6b9dd430ffcccb7"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "540e47c0e117b40891e8e8dae4deb3d13fdfabdd11d536f6810875f16de2f67084afabaf39397e1a264dfbfe2a80f3ebf284250741fdd0fce685afe0016d2a37"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "4fc5e2479bd548aa047c1165a5ddf2580a9efc5c720f13195d4d2b64b115c2bef779acb85e1bf74f0fad20bad47f25d7"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "cbd948d56b16f8c52ba65fb352add38144f4f2db814de2863a0c55f90c5c0943f44bff37c43c83b80c01f6360032417e"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "991e68513b9dabfef7ca77a9961ed288436a5e0cb703e4bc04f1715f121f679e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "2b501b71a17d730c7f2eeb1d2d63710f94856535b7d72f06c6d2fc0cc8300d199eb79bb89429ffb8a99bb8aadc81e2b882cace7799cd27a5d1a26a4ce8af44b8"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@10.1.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://tomcat.apache.org/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@10.1.0?type=jar"
+    },
+    {
+      "publisher" : "Apache Software Foundation",
+      "group" : "log4j",
+      "name" : "log4j",
+      "version" : "1.2.17",
+      "description" : "Apache Log4j 1.2",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "04a41f0a068986f0f73485cf507c0f40"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "5af35056b4d257e4b64b9e8069c0746e8b08629f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "1d31696445697720527091754369082a6651bd49781b6005deb94e56753406f9"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "3f12937a69ba60d0f5e86265168d6a0d069ce20d95b99a3ace463987655e7c63053f4d7e36e32f2b53f86992b888ca477bf81253ad04c721896b397f94ee57fc"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "80b79d5872dec949dff23d221636b5faf312f08fbea2b5e2a8db84a5f5955e13864aff4a288935cb53d4da3d61defbe1"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "0be025582340080ea191c4e2559395fe9957c8d0aeea040239dea8504ce035bd24150162898d18c863092697ef52501b"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "f7f31abcf8b57cf6fd18380b5d1a13f999e3d3d1d89bd25a4a3885fc832f4a29"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "0e4a21cb87a6b8626aa8f580b307039d2b060a6abc53d35feac9ecb8ffc2e80b627a12a869b5b5bf30a6e9348cd4c5c3edca937859141614f3c1b14bd8d4ef93"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/log4j/log4j@1.2.17?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://logging.apache.org/log4j/1.2/"
+        },
+        {
+          "type" : "build-system",
+          "url" : "http://vmgump.apache.org/gump/public/logging-log4j-12/logging-log4j-12/index.html"
+        },
+        {
+          "type" : "distribution",
+          "url" : "scp://people.apache.org/www/people.apache.org/builds/logging/repo/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.apache.org/bugzilla/describecomponents.cgi?product=Log4j"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://mail-archives.apache.org/mod_mbox/logging-log4j-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://svn.apache.org/viewvc/logging/log4j/tags/v1_2_17_rc3"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/log4j/log4j@1.2.17?type=jar"
+    },
+    {
+      "group" : "org.zenframework.z8.dependencies.commons",
+      "name" : "log4j-1.2.17",
+      "version" : "2.0",
+      "description" : "Zenframework Z8 Dependencies",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "04a41f0a068986f0f73485cf507c0f40"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "5af35056b4d257e4b64b9e8069c0746e8b08629f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "1d31696445697720527091754369082a6651bd49781b6005deb94e56753406f9"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "3f12937a69ba60d0f5e86265168d6a0d069ce20d95b99a3ace463987655e7c63053f4d7e36e32f2b53f86992b888ca477bf81253ad04c721896b397f94ee57fc"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "80b79d5872dec949dff23d221636b5faf312f08fbea2b5e2a8db84a5f5955e13864aff4a288935cb53d4da3d61defbe1"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "0be025582340080ea191c4e2559395fe9957c8d0aeea040239dea8504ce035bd24150162898d18c863092697ef52501b"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "f7f31abcf8b57cf6fd18380b5d1a13f999e3d3d1d89bd25a4a3885fc832f4a29"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "0e4a21cb87a6b8626aa8f580b307039d2b060a6abc53d35feac9ecb8ffc2e80b627a12a869b5b5bf30a6e9348cd4c5c3edca937859141614f3c1b14bd8d4ef93"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MIT",
+            "url" : "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.zenframework.z8.dependencies.commons/log4j-1.2.17@2.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/zenframework/easy-services/artifacts/commons/log4j-1.2.17"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/zenframework/z8.git/artifacts/commons/log4j-1.2.17"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.zenframework.z8.dependencies.commons/log4j-1.2.17@2.0?type=jar"
+    },
+    {
+      "publisher" : "Gargoyle Software Inc.",
+      "group" : "net.sourceforge.htmlunit",
+      "name" : "htmlunit",
+      "version" : "2.69.0",
+      "description" : "A headless browser intended for use in testing web-based applications.",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "ceec6d24b07345a12f6c0cec9730222f"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "4a1999521fd0291c70ea1f1e073f8bc16bc113b0"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "ab96550ee724ed4d1e1bfb2d580e291a825a90fd76df33857fd4a4bcc0b448a9"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "a3951d7e0e33d8233aba8916233ec302d7903108e502c24f0f37ebeb68049ea8a3979d6438dc721b1c8f4903e88dc915b083577e8d8b356d0d3a6dc53534a2ab"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "517232024092d9d325743ea65abbfda835dc3960df2d87cd8caa9558d247a9cb7c93998d9407142c9a230082e485b804"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "ec3e53ddeaadda77a0761e593298450045b2a2dd532f4c94924896718e8389bbee6a08480c3423956c57209238631b0c"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "47d1ba14307b35a8f23c75c5ce6e425a709b78e7b5faff33d46a48d9ce6b4ba3"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "df549767d71b2f540103e320a88bf0d9ebf1f2fa2e21f37e70771104bf5a0fc03bed015bb6c545721ed008cfdba3e6ff4dbc3b2e5cd64ad74c3b1eeb6f330b20"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/net.sourceforge.htmlunit/htmlunit@2.69.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://htmlunit.sourceforge.net"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://jenkins.wetator.org/view/HtmlUnit/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/HtmlUnit/htmlunit/issues/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://sourceforge.net/p/htmlunit/mailman/htmlunit-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/HtmlUnit/htmlunit"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/net.sourceforge.htmlunit/htmlunit@2.69.0?type=jar"
+    },
+    {
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.httpcomponents",
+      "name" : "httpmime",
+      "version" : "4.5.13",
+      "description" : "Apache HttpComponents HttpClient - MIME coded entities",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "3f0c1ef2c9dc47b62b780192f54b0c18"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "efc110bad4a0d45cda7858e6beee1d8a8313da5a"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "06e754d99245b98dcc2860dcb43d20e737d650da2bf2077a105f68accbd5c5cc"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "e1b0ee84bce78576074dc1b6836a69d8f5518eade38562e6890e3ddaa72b7f54bf735c8e2286142c58cddf45f745da31261e5d73b7d8092eb6ecfb20946eb36c"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "bfb59447493ea1dd69a0b5a49de8adfc9813d45aae7e005cfe8e6fe282d6caadf7aea520ec6df3f1bdeb99f129701827"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "0c728ad29e80bb4d262d4adf901880518627ab78ef39e194bfce87f91555fc62bf9423f3c15ab7f5c1b6b895865a263c"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "8bbe5a758db8c840cc2d72dc4070c2e264d01fb0d3ed3dd92489e0eb25d030c7"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "76c5f955afbbb00ff00ea39ad2179727c2d7be2a75bd3f654db01e06bb611803bd1258b7527ac30c9d81987b32d1347fbcb23ce967638188672d5ed0151cc791"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.httpcomponents/httpmime@4.5.13?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://hc.apache.org/httpcomponents-client"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "http://issues.apache.org/jira/browse/HTTPCLIENT"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://mail-archives.apache.org/mod_mbox/hc-httpclient-users/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/apache/httpcomponents-client/tree/4.5.13/httpmime"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.httpcomponents/httpmime@4.5.13?type=jar"
+    },
+    {
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.httpcomponents",
+      "name" : "httpclient",
+      "version" : "4.5.13",
+      "description" : "Apache HttpComponents Client",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "40d6b9075fbd28fa10292a45a0db9457"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "e5f6cae5ca7ecaac1ec2827a9e2d65ae2869cada"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "6fe9026a566c6a5001608cf3fc32196641f6c1e5e1986d1037ccdbd5f31ef743"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "3567739186e551f84cad3e4b6b270c5b8b19aba297675a96bcdff3663ff7d20d188611d21f675fe5ff1bfd7d8ca31362070910d7b92ab1b699872a120aa6f089"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "093ac3e2dde58e34aa70309c7305eb3c9b5be2509a9293f1672494da55479a86bd112e83326746dc7a32855472952b99"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "cd6882e7868624164e460f2f3ea01466f863c0dcb902b031c656b57356f563be83b29530df41d88d634ed3d01fc9964d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "710b1d8d7dae0b8e4270756694ca9c83d64965f42d3b4170c609b14d47c2762c"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "276fa6a6599dc89382d658115695cf4da6b0d39b34e9c349c17a5dbd64122eaee553bb9ed75c0378ec4a83be157c8aa39370662de3c9b8fd55ebc1dd608383e6"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.httpcomponents/httpclient@4.5.13?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://hc.apache.org/httpcomponents-client"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "http://issues.apache.org/jira/browse/HTTPCLIENT"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://mail-archives.apache.org/mod_mbox/hc-httpclient-users/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/apache/httpcomponents-client/tree/4.5.13/httpclient"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.httpcomponents/httpclient@4.5.13?type=jar"
+    },
+    {
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.httpcomponents",
+      "name" : "httpcore",
+      "version" : "4.4.13",
+      "description" : "Apache HttpComponents Core (blocking I/O)",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e07a248f61c52776a2366c075dcd4963"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "853b96d3afbb7bf8cc303fe27ee96836a10c1834"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "e06e89d40943245fcfa39ec537cdbfce3762aecde8f9c597780d2b00c2b43424"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "23430cde8b9bed33c91474ba49f1143284135df1b25fdcbc37bc3bb7e9549e77b3918eb40250093db652ae200367e87316129b23b4f6987e94939d60f467498d"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "b776d57492478c162d428bdd3139be0fa6c3cf4503355c3a04710ca7bc3ee74d66627f49eb42814fd8f8364dbd17aa91"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "f6f9e70b76717b705d040f0b33857f0dde89736f2e6d55ea56585235eb1b6d0ce4d5aa18c82050391ac968dcb5ec29e2"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "721a9fc1bb353ddf3e438bed4306a3fa5b55ffafb474be5dc8715bd23d7a5afa"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "c78f9d464e4b840e28266658512b1cab0ece1470bef2764deb2dc20ba69b73d526d92a19494ccb87b4408f9235c4294417f2e10ba709469f4bd62d017b9e3cbe"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.httpcomponents/httpcore@4.4.13?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://hc.apache.org/httpcomponents-core-ga"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "http://issues.apache.org/jira/browse/HTTPCORE"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://mail-archives.apache.org/mod_mbox/hc-httpclient-users/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/apache/httpcomponents-core/tree/4.4.13/httpcore"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.httpcomponents/httpcore@4.4.13?type=jar"
+    },
+    {
+      "publisher" : "Gargoyle Software Inc.",
+      "group" : "net.sourceforge.htmlunit",
+      "name" : "htmlunit-core-js",
+      "version" : "2.69.0",
+      "description" : "HtmlUnit adaptation of Mozilla Rhino Javascript engine for Java. Changes are documented by a diff (rhinoDiff.txt) contained in the generated jar files.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "7cdea5506608ab621ed2ee7e48e3568a"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "80c07e9f939fda453318777a8793cb499c7d86d9"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "38909b94a8a004f9684a7e7a40dcae0c157bf9d72e8a9ddd4c0d2ffd7f899c56"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "a029f0023aa63609f792caca89746cf649cc0816a336de5ede5f2462079baeae6e07803c93ce6d1f149a724814ea28e17314e5c0798c9859d7369ad35a41c05c"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "42fbc55861e6d1b36e6b5cfdb2b382b03394be56e3aa3ed5c669779aa3613f0af114274e0f481f70ac159fc2406ed485"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "344fda9760eec17a0f41b84495328401f3a70640090004fb6e3a8f81b47119364e2f2b3d8b3234deda03f9137b252775"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "160080d8775989db04270efee4a8e6ba805957e0cf3f5a6b8719257e4b8a1f78"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "6dc73136431e228a3eade08de7da10988a4318ea7da48d1b997b731f8d51a1d098cd36a6bf56e8055f8ee723f689af541bd7552492aa0cb0068f8c9619217ca9"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "Mozilla Public License, Version 2.0",
+            "url" : "http://www.mozilla.org/MPL/2.0/index.txt"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/net.sourceforge.htmlunit/htmlunit-core-js@2.69.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://htmlunit.sourceforge.net"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/htmlunit"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/net.sourceforge.htmlunit/htmlunit-core-js@2.69.0?type=jar"
+    },
+    {
+      "publisher" : "Gargoyle Software Inc.",
+      "group" : "net.sourceforge.htmlunit",
+      "name" : "neko-htmlunit",
+      "version" : "2.69.0",
+      "description" : "HtmlUnit adaptation of NekoHtml. It has the same functionality but exposing HTMLElements to be overridden.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "23a3ec0de8ed4eed200dd2ae34dd20c1"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "5cfc420ab39d5096c906fbf105a8d854e771edd2"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "2e8b990fbc83af74ba047915a8d27af063d6bb146338ed828b71eb4cf2536199"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "6e693db24ac0a5fef02acbf169f5b0047411fa7da57c2135f2319710aa1b02cbcc7f3e2b4acaccfe6d9f5d8d098ac2c2b38511519e44b7574c578d2efd52d14f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "e41f7cad5aca9d3747ab545982f63b7325c21b84c36f51a3fafdfdff913f2586be7069a4cb69118e81652a490721602c"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "7111c971514ce9a81c00783e125eeb6a48ea6b98a9b94e757a94ef9b0df2b638db59c6b6d00d62263b1cb1b2efdd5059"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "1f51c0205f0efb807d367c0a1906ef770bcade41223671e78ffea26b9a53234e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b0a869ab94ff3570e114f6150eb889bfec3d31e7cdeff663633cf3c14589592693ea34d3b28948e180f5717fc58de21abcf9f0b3ac1fa5f9ed253df794b04978"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/net.sourceforge.htmlunit/neko-htmlunit@2.69.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://htmlunit.sourceforge.net"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://jenkins.wetator.org/view/HtmlUnit/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/HtmlUnit/neko-htmlunit/issues/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/htmlunit"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/net.sourceforge.htmlunit/neko-htmlunit@2.69.0?type=jar"
+    },
+    {
+      "group" : "net.sourceforge.htmlunit",
+      "name" : "htmlunit-cssparser",
+      "version" : "1.13.0",
+      "description" : "CSS parser for HtmlUnit.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "6a6c39064749cf2809b57ec1192e2779"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "bd4b1c9f12c51687eab4a041eb0e3245c77919d1"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "2c9a117cc5a39605992f5d6a0f9a013d427fecd8b0d939d2b4bc40563f9ba042"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "d0f6eafe6b04e4a8f0646abf515f3238989fb693252bd5f1735b29c83e86cc061971c3cc150d74ddc13fd06195bc308414e46a7e7b3b40d753785a535b43a42e"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "b7d5377246e0d5b441400024e6e0c3fd4c63735c2894145d549769fdeac6ee8140a9d2c2ba31d2633e23ef6608603159"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "1a6a06c2140753389fdd12dd1e55d575d2aa8c3c1a211fc3b19b391cf8ee23a2bf168966ea5b45445825d25732f845d2"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "c4a941dc5973c4c2608fcff3c91832d2621488ff6ab88cf408f5cae11d7a0982"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b7befabf6d14fedb61daed410a48c639e1e3fcbfe06588bc2e6c4d2e4eb90fae704392fef10b4e4493b81e7603903048762920d45522768ab57afcdcf2bd5ab1"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/net.sourceforge.htmlunit/htmlunit-cssparser@1.13.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/HtmlUnit/htmlunit-cssparser"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/htmlunit"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/net.sourceforge.htmlunit/htmlunit-cssparser@1.13.0?type=jar"
+    },
+    {
+      "group" : "net.sourceforge.htmlunit",
+      "name" : "htmlunit-xpath",
+      "version" : "2.69.0",
+      "description" : "The XPath engine used by HtmlUnit.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "83dfdb3db9c55bfbeedafab3cf7886f3"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "e5c5500a2d6eae4e46e0f41d6a59955649f93464"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "95ad144b81713d0953302fa6b2b1aae2efb00064dd5fcc170c1846aac9cb6f3c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "1924c2396d57f1290da6ed959c917d1b93cb5c4a5384e00b68fbf6a6b36472d4a5d4941793c32cb166148caf6a358b6098b40b8b946cb78a0692b18db123e7e1"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "66426cd8796327f57051c1e5bf60972ed0d2065b657ff17a6fa77d64feab9f15012109cbfbb072944be59c77c71a3dab"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "40427e01b97478ff556b3eeb8987c637f752a56ed0e4dce016a74af5704f95be098a0dacb6c5dd0a02a7b812ac9dad35"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a3377295d634a6584c71224ea53ac228f2050724d0c3eb291d75635a40ef6c61"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "e5a124f4d1e200c0b85d107d5c6d8fca83063358cb418fe0e16df14a0b5e7dfa0963ecf0969f0cb5288805434ab7e88f7e20dd2618b6f0142356fe6fc527919c"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/net.sourceforge.htmlunit/htmlunit-xpath@2.69.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://htmlunit.sourceforge.net"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://jenkins.wetator.org/view/HtmlUnit/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/HtmlUnit/htmlunit-xpath/issues/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/HtmlUnit/htmlunit-xpath"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/net.sourceforge.htmlunit/htmlunit-xpath@2.69.0?type=jar"
+    },
+    {
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.commons",
+      "name" : "commons-lang3",
+      "version" : "3.10",
+      "description" : "Apache Commons Lang, a package of Java utility classes for the classes that are in java.lang's hierarchy, or are considered to be so standard as to justify existence in java.lang.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "238dcae7363dd86b2e515a2a29e8b4d9"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "e155460aaf5b464062a09c3923f089ce99128a17"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "28968ae55fff465494083aeba856f8824c34902329882bf61e77246a91e25aa9"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "79f8a9c20da95f68a6f657ad848979f596abe5b633dfdd64fa6ea037f0bdcedd8c98c5f46d62820e4212b2f1177af34ebb615a737bdbad32cbb4cd565ff05052"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "b012706de79372ce9725b50e3234a9a52d2db8c65738abd6affa27840abb9af4683f57a831aaa8a732f771a78063ac01"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "94a22ee3911f4390b1187941596018edcba351aaa908a1ea6ef730f78aa445109953a33c604232bd2ea74a13c5fa0417"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "4c82ebc329a3b08b3a71e3551c634d1dfa6635e4768b06f4db49e28e8eda7dba"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "e2d1217c7e0d810a94dd90dc76397c5d7c33f97154ca0c5c269f737cf556807b7e0d82ab62ee4ba00e420922d752d4765eec411e1b2f89c0acc7325b9774d039"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.commons/commons-lang3@3.10?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://commons.apache.org/proper/commons-lang/"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://builds.apache.org/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.apache.org/jira/browse/LANG"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://mail-archives.apache.org/mod_mbox/commons-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://gitbox.apache.org/repos/asf?p=commons-lang.git"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.commons/commons-lang3@3.10?type=jar"
+    },
+    {
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.commons",
+      "name" : "commons-text",
+      "version" : "1.10.0",
+      "description" : "Apache Commons Text is a library focused on algorithms working on strings.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "4afc9bfa2d31dbf7330c98fcc954b892"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "3363381aef8cef2dbc1023b3e3a9433b08b64e01"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "770cd903fa7b604d1f7ef7ba17f84108667294b2b478be8ed1af3bffb4ae0018"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "afd836a1094449e0a791fee67363666c47b6d24acff353a5089b837b332c0f4af89565c354682521e37062d20e6b52d70c77bb4f24cca9b9532c274fc708a831"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "06c56e6e513dd77cf10d0da46cdea08c34e220e81fa024735b668c6650df4234e564fe865ff5cafea963f56b1e8ffd4a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "f09065ed066c25debf8c78cbb0bcc738e1ea283302ec992dcfb649acb90091cff879465c65a162e94534d454e3b4e9bb"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "0b59c567164bb755f2353b78ba66744000a8c4b35e1df05255b080a21c3a3dd5"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "f0fbce02a862b70f472a27d0722c54ac111ca2eb94584b8b0b73d1926aec26047cd92542ad0b3cf980a6825077587f41b194aa93d6f6350d1b87e59e8df1be7c"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.commons/commons-text@1.10.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://commons.apache.org/proper/commons-text"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://github.com/apache/commons-parent/actions"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.apache.org/jira/browse/TEXT"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://mail-archives.apache.org/mod_mbox/commons-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://gitbox.apache.org/repos/asf?p=commons-text.git"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.commons/commons-text@1.10.0?type=jar"
+    },
+    {
+      "publisher" : "The Apache Software Foundation",
+      "group" : "commons-net",
+      "name" : "commons-net",
+      "version" : "3.9.0",
+      "description" : "Apache Commons Net library contains a collection of network utilities and protocol implementations. Supported protocols include: Echo, Finger, FTP, NNTP, NTP, POP3(S), SMTP(S), Telnet, Whois",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "5254d7c277c30a378518e99b9d1d3522"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "5a4e26802e0a5a42938f987976b55dae4a6cc636"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "e3c1566f821b84489308cd933f57e8c00dd8714dc96b898bef844386510d3461"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "c76a5e586ef9d7314683580442f9ecef3a3c32f85c0539cc62944d5d4471d1ab06f2e9f5a28f444a9add41541ecc6b6f639e4bf1961b2a29515bffe4d591e17d"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "081d2a7131a5b0000b8d6723b079326c530c814a1fc504e60ba6aab527ce8844896b782c424097c3d33310bfe3934026"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "1c3da6c243b6855b95ba625b40a2f0e9ea8c091f5f92735f4f9a620034ce6887ccc1507a483c521ae5aeb07bfc4e4141"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "c7f780c0cd1e1ae7758235b9adf5893c6c503dbaad1bbab96c2804f7e74861d7"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "2346ea5a81ee59eb0f3ed47db11351652e94ce39c4d6ec8f04704d81f51fa0573772625a651f8db665ee3d80cfcbe7ae3decdf753c6e82cceaf80af1b2a250f6"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/commons-net/commons-net@3.9.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://commons.apache.org/proper/commons-net/"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://github.com/apache/commons-parent/actions"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.apache.org/jira/browse/NET"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://mail-archives.apache.org/mod_mbox/commons-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://gitbox.apache.org/repos/asf/commons-net"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/commons-net/commons-net@3.9.0?type=jar"
+    },
+    {
+      "publisher" : "The Apache Software Foundation",
+      "group" : "commons-codec",
+      "name" : "commons-codec",
+      "version" : "1.14",
+      "description" : "The Apache Commons Codec package contains simple encoder and decoders for various formats such as Base64 and Hexadecimal. In addition to these widely used encoders and decoders, the codec package also maintains a collection of phonetic encoding utilities.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e9158e0983096d3df09236f7b53125aa"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "3cb1181b2141a7e752f5bdc998b7ef1849f726cf"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a128e4f93fabe5381ded64cf2873019e06030b718eb43ceeae0b0e5d17ad33e9"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "e8ed9e19b8c836c8bc45469ef1f69792a1a072b9753ee6bbdc7229b6b6b6af8163a7d428f23240093610a96afbc7ff2ae1f08452413b93b78719c9da33470f9c"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "3572d8e8594747696d4278d13b6357611c2740fce39d5a0212ba5e2d3ae90b6c7e73acf8b6d60c88ae27bd68b6e03b65"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "01c13bcc2966bc8bca5ea8622c23674f8e68b150a30afed8911caa6818cd486d401ef6b6f2b6281b3f87af3786e33c91"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "6d60aa770571bbc23a1e632b3ac6ea65148f368607108732f98f142a68267e09"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b803be531bbea66cfb4454fe0f3d4cd9689ae40c96b6e875c1234c26b4ed0692c8f3c23075d699b0ca0ebed828602a004e269926fc092a96565c150aa624511f"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/commons-codec/commons-codec@1.14?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://commons.apache.org/proper/commons-codec/"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://builds.apache.org/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.apache.org/jira/browse/CODEC"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://mail-archives.apache.org/mod_mbox/commons-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/apache/commons-codec"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/commons-codec/commons-codec@1.14?type=jar"
+    },
+    {
+      "group" : "org.brotli",
+      "name" : "dec",
+      "version" : "0.1.2",
+      "description" : "Brotli is a generic-purpose lossless compression algorithm.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "4b1cd14cf29733941cc536b27e6aedfa"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "0c26a897ae0d524809eef1c786cc6183b4ddcc3b"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "615c0c3efef990d77831104475fba6a1f7971388691d4bad1471ad84101f6d52"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "d4cd2b33f7c358012ff01db6a13ebfe1e8051a580698bffcd942c47451012cf53ce49a400b1c8bf7502b01e631d79d7c6417202a145622572d79fd145ccde61a"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "d6b8ad9d0ee6baf8c3a29c1dc2911eaf207352e2c7de893a0185e987e7eae87827890c1d4dbf31c46f25846fbcdc08bb"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "d16c32130bf6b168ff4c8a3dedf1b17787f8d6f0eab9de21e51ed3ab1e7d85925dd02315972f6ca3a4493357aad545cb"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "962dc76a5c487de8d34308860ab65927bf91f50ccb12f37bffb036a7a05145a4"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "a82a3f79b57d30613606ca51dc432b097fa75aab5c87fb45eabec6d80ddeff1b329100b325bb07005aebaec166952c4599a863d4bfd5a684bad21103a2046311"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MIT",
+            "url" : "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.brotli/dec@0.1.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://brotli.org/dec"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/google/brotli/dec"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.brotli/dec@0.1.2?type=jar"
+    },
+    {
+      "group" : "com.shapesecurity",
+      "name" : "salvation2",
+      "version" : "3.0.1",
+      "description" : "Parse Content Security Policy headers, warn about policy errors, safely manipulate, render, and optimise policies",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "128540bd72fe46e53c6a0cfe49c1670e"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "3b0a94fe6fa2f248c95bcb1f342ceabdd5985427"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a1a0f5238a07f246c9e206725f697e5623e93b729d8fd8b148fc627bf9a27c07"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "c6a6039dc4e2f35a9e576f8fb7a66427fa46e9bf87d0b14117796cd3dc87aa184c2f0dc394dc85d913abfa122c0253306e3e72c97613af902852e161369543c4"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "39e72657ace0c54a800d3d7109fcc6ca9e88d43d80003edb0e8e818858de32063063b4bcc18d504f6723caf6e28b8020"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "ab5c429a80cd6dcc3f31790c316c8e6d070aa7c691650c68bfcd780c67a3fefe2315fdadd5f6a720a476c1771f4dfbd5"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "22b1424e415a0a41d36a027fd99d51c2b9305d109eb594f9a5042e19d1e2cf98"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "525ea63cff9e059460125e16a6edf82df553201561f970afad62312df88152dc39e84752af3af6e4b604d0234e8a7d8af8efbf955e88503a675dfa0a627eb130"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.shapesecurity/salvation2@3.0.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://cspvalidator.org"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.shapesecurity/salvation2@3.0.1?type=jar"
+    },
+    {
+      "publisher" : "Webtide",
+      "group" : "org.eclipse.jetty.websocket",
+      "name" : "websocket-client",
+      "version" : "9.4.33.v20201020",
+      "description" : "The Eclipse Jetty Project",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "0e5005706c826884b27b93ba4a163132"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "9db7cfeb5489d6b30189d6b32bc7f27fe9e63044"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "5190bf2722e39c3081533b6b555bc66f438fd1a6199200f04c4aa717edfed069"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "9ca9bd1eadb507a315d90c93a7995d25a24e25b9e22070de3458090f692d17961dca44f483848cf1b827107d592fcb9f82d702fba47c1a046c9a543b8b1a6150"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "86f22a06f8bb44ebbee40c35989efa10378b5d6abc73e9a71f8642c5c4d4dbf9800069c682f855545a7d601f0b5bf486"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "13626a5901274da0408462351af8f2121bea94359e1fa8151d58f527b01b681b37cba31acd2622f9f42b941fab2a69d5"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "ac48d817c22c9bf1ac640161f23cd05d785d442b2e580a35df4accdf58b353b2"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "bfdcaa39b8e3b2725fd2d179030b58a136be53bcce859a65210125262b7950df4f69b30a05105099a148ca866cf481f70d9c1fa863b347a0f3976608cfc4294a"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "EPL-1.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.eclipse.jetty.websocket/websocket-client@9.4.33.v20201020?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://eclipse.org/jetty/websocket-parent/websocket-client"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse/jetty.project/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jetty-dev/maillist.html"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse/jetty.project/websocket-parent/websocket-client"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.eclipse.jetty.websocket/websocket-client@9.4.33.v20201020?type=jar"
+    },
+    {
+      "publisher" : "Webtide",
+      "group" : "org.eclipse.jetty",
+      "name" : "jetty-client",
+      "version" : "9.4.33.v20201020",
+      "description" : "The Eclipse Jetty Project",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "3ed19f201dd577d707b8aaf63a07b7d4"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "debfbdc2bc4b02fbb593928910b163311ecb2edc"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "9cbc23fe5ef74bc16f4dd6ecd518223ca9979e0cfd2c5fb9480d63f1c1dd9c21"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "b9e8dd2e540d1cf36fb8e6cc953498a6cc7bebb6318cfbf55dfec0665eeb942f3f85f3cd123d08f8ee92c851312c4326d096ec6b0467e91c8f8ace7da1d09139"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "e30770617db8f7ad2563cf5691a0e8012604458e57dc56f1eb3f3822a725889a0742843e64c26db8bf7a9ecb509e1161"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "2e33e2f2903602dfd2449e65ccaa22aff1140cf0bca7e4ecda9efbbf68903bcb261d7c6b366df77404ff52a798d4928d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "739251f13b3968bbc004618148604ad1867a95854428e08db8493e2e236f60da"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "149b26f2adf19a378cc1d6bf91e3c59297a05c0989f9fdcb682cb4278c4c2856044e4e5c9216881eeb35342d28c8053a9b5bd7ea83cc6a259fbfbfe3a068ac61"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "EPL-1.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.eclipse.jetty/jetty-client@9.4.33.v20201020?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://eclipse.org/jetty/jetty-client"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse/jetty.project/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jetty-dev/maillist.html"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse/jetty.project/jetty-client"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.eclipse.jetty/jetty-client@9.4.33.v20201020?type=jar"
+    },
+    {
+      "publisher" : "Webtide",
+      "group" : "org.eclipse.jetty",
+      "name" : "jetty-http",
+      "version" : "9.4.33.v20201020",
+      "description" : "The Eclipse Jetty Project",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "3301a71b84344f7a0062a8ec789741f8"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "ad28940f89ffde6ec1bd1656fe3f8493b01ba3c2"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "cd276f1499beda609ed7d7f9dcf254f1b279303fd0af4df891d9ff8ebcacc688"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "9abb4ba6802c39526b755429e3f41d641408f91f1c48844cd56cda116fb1479f05f1a3d90c18f30386b07d5593221c1f85ef565da0c6121b6ff005ec7d9c3bd9"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "aaf1cd2a2b49bf87578d3e5d55f38c7810d1a979b6937a92e301264ea874d1927b9e9e5e2b5328f1d5ceda98669047fd"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "640acd12bf7fe5f316d2aa8769ac699cb19400a309bc9ea44cef6294f1fe4cdd77e24bc24cc385e2087caec3cb120390"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "9620f869f7b72cbcbdbd52fc8dde0a68c421ed331c3e62ae5894227eeaf067bf"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "ea1d09a7e03c140bef9c9e521cf7bedde1532006a72c8a3264b1cfa1ffd0d01f2279971ea0575f2851d3e776bc74d6fe301bff60dbd34fb77b0aa525d521accc"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "EPL-1.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.eclipse.jetty/jetty-http@9.4.33.v20201020?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://eclipse.org/jetty/jetty-http"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse/jetty.project/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jetty-dev/maillist.html"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse/jetty.project/jetty-http"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.eclipse.jetty/jetty-http@9.4.33.v20201020?type=jar"
+    },
+    {
+      "publisher" : "Webtide",
+      "group" : "org.eclipse.jetty",
+      "name" : "jetty-xml",
+      "version" : "9.4.33.v20201020",
+      "description" : "The jetty xml utilities.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "afb4444bd1aeec316787cab83b7c38fe"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "77b4f176e70b45b9708dfe2ee48a9f26ca8d9859"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "5879b9781ae0e659f979bfd9d8840866f1ccb8d6953d0e0727580c26c1fbe543"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "bd86a2a196e5f4bfff4c864c33358b0650f1b4312e42c76488fda6604981568e72963461d46b00dc43d2f5c25addd6b18f39d4a89d22bc342a83ecf30c463844"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "8f40feabc3557d2d515793d77008b0dcfcd95478edfdeaa298c9cfe10f4172e9fb3570fa89870d12e82500d0b231da27"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "a895fd28f9c342360c6cda1d77535a91a9b93ddfec2c05acce4a1b34b283fd4c56e26a8a508079b8fe60f01723f3ea0a"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "783ea6b3894848c456b4a1e3c94bae7cc27b1c5ff615d7e8e75842ee26b775ff"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "c0e0c5c6cc4ea87359f40fb8fe2738ae09b23b3b38d6969760c47f0ab3407d47b028e765885e41bec7cef7e047f32feecc89342bcf95d50867b40f41c3ee2432"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "EPL-1.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.eclipse.jetty/jetty-xml@9.4.33.v20201020?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://eclipse.org/jetty/jetty-xml"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse/jetty.project/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jetty-dev/maillist.html"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse/jetty.project/jetty-xml"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.eclipse.jetty/jetty-xml@9.4.33.v20201020?type=jar"
+    },
+    {
+      "publisher" : "Webtide",
+      "group" : "org.eclipse.jetty",
+      "name" : "jetty-util",
+      "version" : "9.4.33.v20201020",
+      "description" : "Utility classes for Jetty",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "4bc3734f6738dc02c7f79a03e730526b"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "c88807f210ab216aa831b48569ef50bd797384bc"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "ba22ac5bc1adfd571fdfa12f17b87941b13709f861ee7e65fcea623b44529e64"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "35c5ad89d92e77f542d3ce42249f01c478706e2a013c5ab6a9504cf43520e3de90280d82a11389e9909060835421e3caada68e77d86df76a84856be60361d550"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "cbe79825c01277455138a1ebd79db53541ca5240d132e1b9fcf34ee60b6dc378f951709914e5a03525afd480806a5ec6"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "bcd10bae1c97adbcdd979a314689ffdd2e008fe0b83fdd469661e968c7a7205854f0fbf46c37b7265f83694f6b7da7ca"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "441a4f9c34608de849c2c3200a771bdd95a34e4c470f265e1e2e07ca53f343d1"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "3827e25cf4b6342e7ff5240a573603fa1695e9896d90532117bf872ee3924b4d5ef04fd74edf49bd85cafcb2b631376ef82941e74568c82c4c14f400161d07cb"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "EPL-1.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.eclipse.jetty/jetty-util@9.4.33.v20201020?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://eclipse.org/jetty/jetty-util"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse/jetty.project/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jetty-dev/maillist.html"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse/jetty.project/jetty-util"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.eclipse.jetty/jetty-util@9.4.33.v20201020?type=jar"
+    },
+    {
+      "publisher" : "Webtide",
+      "group" : "org.eclipse.jetty",
+      "name" : "jetty-io",
+      "version" : "9.4.33.v20201020",
+      "description" : "The Eclipse Jetty Project",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e200bd85c6b816ca0698d29fb8912942"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "9e4b0048285b71f4769908780f957a470eca11da"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "65030f269fac616919d7bf33ac9a3785e1519417bf109d685d45726172f28281"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "33ec09950feb1f987dee16a769c9395a9767b4276d14f712e33f7d9405e50a16d3867e99f86edbc793f7e2515ed3e9c6e0c0e3e4d2fb83c8385feae16e135fd7"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "a53ee8c2a994b2a745915ac0922d0b6efd58e59a7dbc5c8afc09b511c96ce046555e5550df4fd9e4e860b69a559fa7df"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "d173914b20eef7e585c5ba8799cf608ec574e580e907874e59c6e884e307426262b2656073af5f73a35284ab5b6b387d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "8f950b081399da7c8b7ac4de5b171619c57aa9939de355ef3db50fff48af62d4"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "fd43149ae63678261165cc439e8e85acf15fb5da5e48670047185aaa607cdf1bb9ff725c59f54852e37a0fede48d05139db991e74bcebaea321c13ea26ec5552"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "EPL-1.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.eclipse.jetty/jetty-io@9.4.33.v20201020?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://eclipse.org/jetty/jetty-io"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse/jetty.project/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jetty-dev/maillist.html"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse/jetty.project/jetty-io"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.eclipse.jetty/jetty-io@9.4.33.v20201020?type=jar"
+    },
+    {
+      "publisher" : "Webtide",
+      "group" : "org.eclipse.jetty.websocket",
+      "name" : "websocket-common",
+      "version" : "9.4.33.v20201020",
+      "description" : "The Eclipse Jetty Project",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "b7722e78198512bde021a7a629c24566"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "abf7ff6c6bdb290019f1642bdf9a00867c0a8733"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "db0281ba4ebdd87bb34dff1846694d5a7844d096c4857e6a8a1b4d6a52703001"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "c4d42a17b3c7532805b2d035e065222cac54aadaba850774fc78b095f4ab227286d3bac5ddb045e05b12f08ca88fa2cbcb2e6495c45c8ea048c1e24c65597aec"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "d214a9bb25a0fb83050fac12d4c464226bbcde3b00f0b277e0970fe81f6a07e8deed2e072769b6d3b688f94fc702d31e"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "3abe7a091ad7593cd51961c7c0d4eb485ef7c1150f3fb09de5eb54baad172068f47cc416f4e1f520253866cae98884cd"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "63496dca71d04d9e192611b4261af0c8754a9611e778c0815b3f99f1935297a7"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "87011871564b0fec1ca3476627cec58b2b772a4160be87aa643b5c71fa9060fe4954155a445ed454a7ab20bb560199d05e7e21dda7d1725d500c87ef1513357d"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "EPL-1.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.eclipse.jetty.websocket/websocket-common@9.4.33.v20201020?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://eclipse.org/jetty/websocket-parent/websocket-common"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse/jetty.project/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jetty-dev/maillist.html"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse/jetty.project/websocket-parent/websocket-common"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.eclipse.jetty.websocket/websocket-common@9.4.33.v20201020?type=jar"
+    },
+    {
+      "publisher" : "Webtide",
+      "group" : "org.eclipse.jetty.websocket",
+      "name" : "websocket-api",
+      "version" : "9.4.33.v20201020",
+      "description" : "The Eclipse Jetty Project",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "2bf9d049e5208b8221faa1e5ab36c68f"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "71732cec8884775170f0ac0d21fd2d59883ff35a"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "22be2d0531c7fdede617e19eb6ed3698ad73c7f79b2e9dc906ab274ec39bd505"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "fcaefd1e6b43ba2d0679a26a9904679e0a3a30f5a3dd41445fbae5a7ff586fca51c5561db5f615e955178d5698f31bc42c1f3829d9d1b34455b4acc1f882fe4b"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "55834afdf3497a713276fa01fb7c12f74b41d9b047d9a252f46bc7048b0ecbcdbf174005f1dbed53c57ba649876a4e0a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "0ea0641395ba2f89a7fdbc634878290f8714fa4cd3e7ec081caf1d4304608f23ecd4dcec62f080fb74fa0778727c441c"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "4238f67b98a3ce49e41238957136b3d636955c440b308ecb8877144fbeeed9bd"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "016ef601059655ead32bd689cd21df4a9f9c9c4ac9d207ad196731b5e81a26912639b4a9f9f3c9f2ced0d579731dc25c1191c46b57b3fdac56843b8303d1cc11"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "EPL-1.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.eclipse.jetty.websocket/websocket-api@9.4.33.v20201020?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://eclipse.org/jetty/websocket-parent/websocket-api"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse/jetty.project/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jetty-dev/maillist.html"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse/jetty.project/websocket-parent/websocket-api"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.eclipse.jetty.websocket/websocket-api@9.4.33.v20201020?type=jar"
+    },
+    {
+      "group" : "io.quarkus",
+      "name" : "quarkus-grpc",
+      "version" : "3.2.0.Final",
+      "description" : "Serve and consume gRPC services",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "de554c9400862ce730dac0c365354d5b"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "99c26f75bbcf8d332ceecce0e9e6f62b49a497c8"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "2a9f9206eae96a861c1a5ed3d02ad4f44a814d67b9ec1d578ae8af8a08baab2b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "5c7ba00cd904fc21c81ec17774ac678cb0ce75eb66d36f1a2634ebe3ee02f1c3c25c7a49f763a854508f6e7aa03c8cbb08cadb8477fed8ad05869102bccb2816"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "e6dcfce7e24b4a19d731e5fdbd56f82a1c36e6cfb3a2949be7b411eb82466f1554c19ee374822e409c4c1ec8f589574c"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "c6676870001bca53cd9e720542efefec014b1457b8de50a4c8d741632636e9cf122cc7be3b81d44f2960855083ce957c"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "64ddd463a5ba91cc322b72f6e80c7afcbc15d8d1a0a04994a75b5f8fb2fe5357"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "e8fc445af26f82ed2caf82304e0735bc3ce6c8a1ee4efae2ee3ca5c23c61ed587a993abd6d57ef44c067012a18f70814ffe40888bc384699532f8dee0b0abbe8"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-grpc@3.2.0.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-grpc@3.2.0.Final?type=jar"
+    },
+    {
+      "group" : "io.quarkus",
+      "name" : "quarkus-grpc-api",
+      "version" : "3.2.0.Final",
+      "description" : "Build parent to bring in required dependencies",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "013752a04f0aa63e2b887f1e9547e921"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "b56d30a95455480b1cae1243ab90519acb2fd637"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "cc37f99a358b6a418ba5638fbbb8c20e5ad26f5c7ecf371ea298b8ce098da744"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "cd942e0449fd3724682d6ef80d96e408d79211b9582b0e3e8e34fb6600713e80142282f29a3fa29a42d972dca10c782af8f3feaaa3bdc8970df6bff322dd2ffe"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "f315483742c1feb7b1e910b1a3ff2cdbaf752732a2e94329e39c879b44b0884e43222e93351f14a44cd00643d610ea44"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "cc48f8807c2bda238ad1c8e4f75517e39bb75fcd269673aec6332d93f2bd30e18b8d2f1f728c16f037e8fb2d91860123"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "22febd4a6b3a8cc4f8a0a7981beaa9c2f7e182f4791e68c11b696a73bc335396"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "25f9fc7c6d3cd3e75472e1c8f1ae8645b2bc66515eba52b9d75d14ffbfe91f9affbfbd0f4d62f7830d5779f9fc1cd1f543f2360eaa228faa328cd5ff48cc78eb"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-grpc-api@3.2.0.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-grpc-api@3.2.0.Final?type=jar"
+    },
+    {
+      "group" : "io.quarkus",
+      "name" : "quarkus-grpc-common",
+      "version" : "3.2.0.Final",
+      "description" : "Build parent to bring in required dependencies",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "2856cb7304c986de84753664d43b5ee1"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "b59dc8e6b829b02c17ca336d3e6d5c2d2f26a307"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "bf121c2ab5317321aed5bbc246c98cbea653ba5906e23d96d209d914ee1d2423"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "5ce1cec72170c89fc303ffbc797bf470e3375a0751e9533169e8608ec2ed39e9d9fdd88f10c222c17f5af5318b2710dfc14b6bcd97bed071d1f52812be93084a"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "24643e750c6bfe7df03e901b3d8fcb9b60c31d4ddc624ad983c1a838fc3044a47a2b48a9480cf4bdd6dfff4daba5da7e"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "34682bebf592351b410436f57c8263d6f1d442bf5a57b618b5a9a4a2bbec13776bc12f26269730ec2a720dd02fe38573"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "55d656abdf1ea90c367c23f67749bbb1b7d22e2d68d85e3d86c36a9740801a25"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "d897041c254bdc01988fbd0e03bfaad4f28070022a3756864526bc01f899bdac753e377b87b5ce77bacc46c4a618e01c364661bc04206c0d4fed9cca805b2959"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-grpc-common@3.2.0.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-grpc-common@3.2.0.Final?type=jar"
+    },
+    {
+      "publisher" : "Eclipse",
+      "group" : "io.vertx",
+      "name" : "vertx-grpc",
+      "version" : "4.4.4",
+      "description" : "Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "035895124ff1b8fc8468d995ae4bef10"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "177c65b6a7a316dea7b0698b0f16b92c476fa8df"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "7fc96f0412616434123c1b5853e1fffed63212cb8335840e9f3da57a948becf6"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "a83b90c4fe36a64c63957a098e856d9bd6af6d7538039ab859411a7b381a19619047810a727da6e7087351637f662bd92606adb3e89e7dc7193c068f90226ecd"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "c76e6ccb37719339a5122003b0e2f0c7d47b29136144b319d3faba604b3cce2b73000296605f1eb856956c4a043ad9a4"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "66c72dad8648ddfb2f56ff207611fdd4325b74d12edd6d0e45e858bb90512942cdc286fe9a69c72e99ece58554115439"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "19938e51cd0a489be6e3eb526481b0c89f20073715a592094d4c514c6aade8da"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "7ddca43917c40d57b092403141f7415b9cbbc388e80c95c7c3c6d446a474ef276ef7e00fc1b349cbc9c41bede9d95e60fead0bd638169d2e459fc98f101c9d41"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "EPL-1.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.vertx/vertx-grpc@4.4.4?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://nexus.sonatype.org/oss-repository-hosting.html/vertx-parent/vertx-ext/vertx-ext-parent/vertx-grpc-parent/vertx-grpc"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.vertx/vertx-grpc@4.4.4?type=jar"
+    },
+    {
+      "group" : "io.grpc",
+      "name" : "grpc-netty",
+      "version" : "1.50.2",
+      "description" : "gRPC: Netty",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "84854d44b71b8064dc86c98aec8cf848"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "5079c023b7f914f6af6f624ee60333442d7cd7a2"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "5f69b7e2b7a219f96a3ade738ce64a2ed142a6ea938ef6195ecbb31041378418"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "dd8dde3c1c3e2e4bd2e9fe76cc070344e8d100e8b08d11dc04a81d05e39b380f2c7a23d7c55669b5d97cfcbe5c3d295f762cf1f80f2b4d47a6350698268c2bf7"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "99a0bd09050b519e2bfc26451fd717aabb1020da8717367ec16fa4b589549612ecb815451331b32a7790320ac75319a8"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "a807332b16838995dfaf367b1682a714770b2990108528e4adcad9f31c425c7c539ea1afc31be2b808ec3594b3febfc5"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "d1e08218453dbe70df18be1d9f3955c437aaef45195793fc1bb78b15f7001a79"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "2822656fabcfdd582262daf6dee8eaf37a23b234ac151d0172995657b6988635d9560bf170cbc6e7c73ca9259bfda001967f3d8e8d0cae62a638899c91ab4333"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.grpc/grpc-netty@1.50.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/grpc/grpc-java"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/grpc/grpc-java"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.grpc/grpc-netty@1.50.2?type=jar"
+    },
+    {
+      "group" : "io.grpc",
+      "name" : "grpc-core",
+      "version" : "1.50.2",
+      "description" : "gRPC: Core",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "d10c77d924a571b48bb6405f73932d46"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "848c5243dc4a69553953faf1cb1de4d01f87b602"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "c52eaab84a8d80c715a345eba7d97d7496ea8cc411365e03424ee520b155f2b5"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "0483285e0df1f326d00c1e49a773f75edbe0a7e40128f102259f7640e8300b1239b272bdb7d5618c54eea69530cc7bea28f3405bad7094650609a2d72a4e0070"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "389d99e03ef882bf477ef69f9803e91eb159bc1b05e37c02fce597c96ac894c7ee672c19688d9d5b7044480ca4d55885"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "8f423a57f5bc7f06d9cc9152f189532ec63407aadcec59b6bb743299f151a786cc63e8c59d414ccbe8ed36367e86bb5d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "bd5426496903a6c4d5ddcee4a539eb8bbf12e1671fac951183184c3d000dd547"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b7920b969a8de7402abb00b350c300a570023eae156ecadcee33ee7fa7cee32c1be138091e777a088997702070394ff23531533b2479ee3b3842ccb639a3972f"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.grpc/grpc-core@1.50.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/grpc/grpc-java"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/grpc/grpc-java"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.grpc/grpc-core@1.50.2?type=jar"
+    },
+    {
+      "group" : "com.google.code.gson",
+      "name" : "gson",
+      "version" : "2.8.6",
+      "description" : "Gson JSON library",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "310f5841387183aca7900fead98d4858"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "9180733b7df8542621dc12e21e87557e8c99b8cb"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "c8fb4839054d280b3033f800d1f5a97de2f028eb8ba2eb458ad287e536f3f25f"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "902a1a5dce66303abff2ac4b8a2319035f718c42590c1ae593825cfb85a0003e52c3492fc7ae6b86eb3ed16656dc3fc6b918aa807b20b759d4753cb692031740"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "8289cd5863d035279a59fdf47febb53e39aec9bcb3da8bee14fc9911ee78d52e801f73ee3795cc00ab146baaf78f6181"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "f0152ec3945a39511db66831bbdb87b685112162f28591e9f99e4bea602a58da183f29d8135e9305627e795b798b5906"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "8ed3aa4fa98a5ce64ecd36a22576e2e02284edbc409eacb8ff499e5c2cd3dd8e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "8edc61bdbd833a94238769cf7a0b63c1cd11ca2581ac4dff0f4bace389d2d321254df3568759d06b8ab5c0899fffb4359b29fc9e511a81b466f6b18e980b6a6e"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.google.code.gson/gson@2.8.6?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/google/gson/gson"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/google/gson/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/google/gson/gson/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.google.code.gson/gson@2.8.6?type=jar"
+    },
+    {
+      "group" : "io.perfmark",
+      "name" : "perfmark-api",
+      "version" : "0.25.0",
+      "description" : "PerfMark API",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "6860016b29a2dc46de730bfb7c750a23"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "340a0c3d81cdcd9ecd7dc2ae00fb2633b469b157"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "2044542933fcdf40ad18441bec37646d150c491871157f288847e29cb81de4cb"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "c9f4fed240e56db150d178a26ce0836c9efc223c77054e57e429d55296987b971a93a2af0a351856442123857694019eeb85648d892abec3f9c4c0d850e51bb2"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "b70716efce9b6ead1b5addd4d08bb036833a405d71d8ea70ec5818412f9818b75c3d7651415ca9ba740fff659dc6b8ce"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "33bdb62d7230d994db1213519a2b8df5ad805c080b454284d216679d817459a9bb0640ad9bed8907eb015d89ba19ee0b"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "8065ee53c98302b2a0c8ffb63bd7029d41238915f939ba99df5e8dc05ad8ffd1"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b65054c32c16f6393f2a16c597d98e10ce98bed8d60da1fa4d9c0b2bae2f878e759e73e0a9a8b232acea9933f912bbfcd7a13e9045bdff803b3f21fee4179bef"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.perfmark/perfmark-api@0.25.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/perfmark/perfmark"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/perfmark/perfmark"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.perfmark/perfmark-api@0.25.0?type=jar"
+    },
+    {
+      "group" : "io.grpc",
+      "name" : "grpc-protobuf",
+      "version" : "1.50.2",
+      "description" : "gRPC: Protobuf",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "c3b7ddf5f42a2d0c438646d1df92d58b"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "3e8b75be934471c20d76e85e4c411d164d07b219"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "5892eeb2fdf819eb8a66f6d88980f4abe38258faf0c32c070526560381db473b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "89d733f8dbc68adeed89048af76dee0db2597bbeab588a964129d751c671934051aa49df3a7c16b154610d13a290f2472d73b2a0a1f7db214fb74c03a96b0574"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "6f991884be38932bbd1d34e12ff17ac748f193ea3bca66fd812f8e28eebf47fd575b01f1a165a16fe3fd0427a00f8f8a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "8b8ad213ae5a115a3c544d7297d65472bf3ebdff720c249c7762bec54bd3e0a17916e17b07617471599d23bf09e9b07c"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "272669b5fa4ecd0e258c903a069a6accaf93efd9b2c1828014304c5056469e72"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "f3cecfd114c458de9760668f4adf11304ed405ecbad3ff84b26ca8c04dd453879989ab20bb43318e50df16b9df3ffd407369aa3d1c4897c3583970a01b38de40"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.grpc/grpc-protobuf@1.50.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/grpc/grpc-java"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/grpc/grpc-java"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.grpc/grpc-protobuf@1.50.2?type=jar"
+    },
+    {
+      "publisher" : "Google LLC",
+      "group" : "com.google.api.grpc",
+      "name" : "proto-google-common-protos",
+      "version" : "2.9.0",
+      "description" : "PROTO library for proto-google-common-protos",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "1ed1601165fd88b371b1f3d8a2e480d6"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "e4ada41aaaf6ecdedf132f44251d0d50813f7f90"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "0d830380ec66bd7e25eee63aa0a5a08578e46ad187fb72d99b44d9ba22827f91"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "d52de131cebc0120860effd8a3a0a0a5c0e5744047a3ec47d1e7a982463f0f66131bdcf35f0c49d0dc9d0938e63a3961b6dab6159261a9713da12affa23faf57"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "00cb182ade91d9bd6446970307a698eaa6ac1e618b87d9d2ed8a27cb71ccb5cb0b47c08aed9beeb5182df7cf14d960a9"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "4e92f0167363f76f408a19be0fe58c10cb0a44caeb29c49726f9670d045adea51114e092a45842ce2a56c046959b1bd6"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "c136f1085e850f329939f284e01091cb5521d355171013a9c7fcc0b699f9fb4d"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "2be9684be1e7c86f31208fac30be666e2f6a73e6745de89b7a234aba8febbc265002bcadd6952b2d1afd08009bb494b36e2a8ae62d70c22a0b797eeb1c2e5f93"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.google.api.grpc/proto-google-common-protos@2.9.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/googleapis/java-iam/proto-google-common-protos"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://google.google.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/googleapis/java-common-protos/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/googleapis/java-common-protos/proto-google-common-protos"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.google.api.grpc/proto-google-common-protos@2.9.0?type=jar"
+    },
+    {
+      "group" : "io.grpc",
+      "name" : "grpc-protobuf-lite",
+      "version" : "1.50.2",
+      "description" : "gRPC: Protobuf Lite",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "3aa89afdc2b54e14911e7f912e7bf551"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "1cdfb6ec3de18836c00175e81607b57122757d48"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "1c68aabfcc02414961c434d12840b44559fa66f51bb95acc5a144bf3aade95c7"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "8cad3d568202ff9171910307b8afc59f39452e616ceca1ad67a448cf312332d13005db695034ec2d28ef0cde67359802f48b7ed59e4a0545953a44d986f409e8"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "438b1c68a6ee82dc98fae6db3da9bd414872abd6bcdbf47defcc9bfdaf6b197047d089e80d6f5bc412b57f7656ea4747"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "21f35735b489cbcddaa49458bcbff91399269e501ec37763d2eb0e8a730198fc34630427a9206b532cdaf69bea228b90"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "22b9c3e9a17d80d1de444a6c8245e924e86e0328eb74391759d72b02c6d7bf4a"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "f307ccfaf6edf1efd8a3c5fb363d8b61928f54db699a8950c98b6232bb307b0490fb40ba0e38c32a66a193f448722db60f686b38ff72da8b52a1d1f2831cc82f"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.grpc/grpc-protobuf-lite@1.50.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/grpc/grpc-java"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/grpc/grpc-java"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.grpc/grpc-protobuf-lite@1.50.2?type=jar"
+    },
+    {
+      "publisher" : "Eclipse",
+      "group" : "io.vertx",
+      "name" : "vertx-grpc-server",
+      "version" : "4.4.4",
+      "description" : "Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "fdcab6a4d694bb5ee9dfeb2641911bd4"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "2dd5f73a67e8a39c4277ee873db9c6fba14cded0"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "4b90ae0497f65ac5a3d9beaea2707da87c4fce5715b55081ec1447b8e09ce746"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "fd00b640c37960e3c4dd6c20efd4c066ab995f067b3278deda5f5a820498251adadf51b645ed6b590b3e0a2928eeb3527b0687974760f89fe3963de47e8bedad"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "7f167ed1f39926ac5f5cad6e0c8ff22644c028952abdaa1714c6f7e08b057f0d3142aa485fed76aa77faef1bade387be"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "2ef395316e3c99d1fc63da4e2b4e6e3c3e4fb9e98a1458673e250143a4e626ca57e98cfbb33f12f87e9ee5ef06451dd8"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "f4103cb95669c7e76d34b2a85dbb4deeb265ae9983812d3d811fc760c78fc850"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "8b4801118fc1662904776289c6f293a988e13de52b821e8f2f93e4fd8b5bd997d32bc6481ecb2b8d73f66c6c05bc4b3defa2626ad7d19821580248ff060fb44e"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "EPL-1.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.vertx/vertx-grpc-server@4.4.4?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://nexus.sonatype.org/oss-repository-hosting.html/vertx-parent/vertx-ext/vertx-ext-parent/vertx-grpc-aggregator/vertx-grpc-server"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.vertx/vertx-grpc-server@4.4.4?type=jar"
+    },
+    {
+      "publisher" : "Eclipse",
+      "group" : "io.vertx",
+      "name" : "vertx-grpc-common",
+      "version" : "4.4.4",
+      "description" : "Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "52c53bb6b1ea4d4dfe4c564505f0ebc9"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "825c3e4159e0ed9f5f7eacc1f3a24122f148d298"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "5cd9ed1422d9195b1c607c3ca176ccd3825f9cbdd4e3bb782c205e39288d121c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "195456f428cc0c1c3b43a55927df0a338a5c6e466338dc2d7c304f3059c155b7ec1eefaca62d7a9f203a2ce6543bc429a9643c20742d44c1328a6d3bf33b2679"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "2b15bb99390e0f5e32675df58bfb517b8954e210937eadd2fffa2a57ccbf13f4f126ccd36f373a2b0db2a780bac93674"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "a160605fa7b9a19d762014ec214e0bf4412f2483b0d7f71e189b8164edbc1b820abe25fcf88ecdf8d48e5d5c27f21d44"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "c2dfaf267c115018431652d3215358c07d9ea97931803616717994ef2062dc62"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "fb4984f94b8c13327c1906099c5b4868864430220f1d30f6e209a94d96aafbed2fa89b47a543eb87874f1d78d93add912f53d53267ddb3b33e323bf11aa5d9d8"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "EPL-1.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.vertx/vertx-grpc-common@4.4.4?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://nexus.sonatype.org/oss-repository-hosting.html/vertx-parent/vertx-ext/vertx-ext-parent/vertx-grpc-aggregator/vertx-grpc-common"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.vertx/vertx-grpc-common@4.4.4?type=jar"
+    },
+    {
+      "publisher" : "Eclipse",
+      "group" : "io.vertx",
+      "name" : "vertx-grpc-client",
+      "version" : "4.4.4",
+      "description" : "Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "769345994d8c1e530ed9281a92920c1f"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "6842cfaf9d489e529d079a38360ac552ad093973"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "925a2bc95ff77f80d4811476252a182b332c4a7275cc89b5ed064751a0adc303"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "fe64949e7d5771557c6f107337e139579a10f3e8a2c3acb909d327be1d12c7a816ce60eabedb2cfe07d22ff2aab393b51cd923a8254d1af867485fc08cb389d4"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ed3078dfd9a34e6dad9486df836ae7b65f584700537892b230bb2b9e0c0d9bc1055c9582b913f8faf26fff7de22f0f92"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "71c68f490544bc11e82b38cea3bf0ac341e36051a5d07e4c124439d9dc539a6a7d84420ccf7af90ff8558882a66d177e"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "f723d42858350543f01145e0970f24d409a074b14b4f306044b77370316f10f6"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "22692f1912b7016652b2661e5f873a3ff2794e9cd69609a2436915b9a2d2ef328027ebb564fc6e1638920d10c0912dcff9aea7f3e6f272b8024574c4861b265c"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "EPL-1.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.vertx/vertx-grpc-client@4.4.4?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://nexus.sonatype.org/oss-repository-hosting.html/vertx-parent/vertx-ext/vertx-ext-parent/vertx-grpc-aggregator/vertx-grpc-client"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.vertx/vertx-grpc-client@4.4.4?type=jar"
+    },
+    {
+      "group" : "io.grpc",
+      "name" : "grpc-api",
+      "version" : "1.50.2",
+      "description" : "gRPC: API",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "1f1f6d921e53ab5eef9edde791c5a177"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "8840eef194d786b8d97d820b8ad4efd219553b59"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "5c974aedf2ae529612b2a8ef697e3a623424a37e74951d7b4c867acf9ae58e38"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "239983594ed85f7276c844f5804f3935d511cd8183fb134ea5993ef853f23a83ea10f2201aecc3cafea5444f6a2f1ef7d5d847795152d386216257a41ea2cb7e"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "738095003e3c65961d136516ef311f77b8ee2d00237cbe2970182d5be6169192d03d086fbc4bfd333342571502f26b7b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "6530a59b4676da4638861fdbbb88e035ee520fa3317484ac85680defa3e1c5c3625ba86dffdc42407ea5f1214164fd43"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "00fb077eed4d1b2e726039c3504de20a78b54d68ac58afe0365b9bf000949fe4"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "ab21992f86f2a43d8d6810dbf9b77daa4732c985b9720aaeb17ee5793315b8263dc031cd1c9e06a841801df2e0431feb451d9f88888277948b22bbbd897026a9"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.grpc/grpc-api@1.50.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/grpc/grpc-java"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/grpc/grpc-java"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.grpc/grpc-api@1.50.2?type=jar"
+    },
+    {
+      "group" : "io.grpc",
+      "name" : "grpc-context",
+      "version" : "1.50.2",
+      "description" : "gRPC: Context",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "b9207b714beb1415d0b0fec0055ef3c6"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "ad433a34210e1d02e1e208c32b6a69886b64c8cb"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "99d0639588c3988a816469610e93033c154cee0cb44d3e54f6e73d0b5dec930c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "909b9a8520b9375314af7c0db2fa76844dc1dd16403a8f08f160f9e97ffdcc3ce7597085b1695025fa331995697d575f099be9bff03d5fd60228204b9e5db123"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "3054b666da7a258f30a63e527b46494288a1fb80acacb751d59a058b483407a1bc4551100a5566e4cbceec8912d18773"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "6116884c5e2a3ae179d8146a6795ef7756a8f34c01881063fe9a5b2cb4dfb6036d8b78a60463c072ac84006cd59e291d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "8697cd2796b69dc3310054a369b7a5d2f49d748f878cc013086bb2f8e522e6d7"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "270c2d3a201c980161a303577e228aa9444803fa09a393200890d0b2c48f08a9da0abcd9dd021df1b1482f6f754d835ccf9d715034b98362a6654538ef78ebbe"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.grpc/grpc-context@1.50.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/grpc/grpc-java"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/grpc/grpc-java"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.grpc/grpc-context@1.50.2?type=jar"
+    },
+    {
+      "group" : "io.quarkus",
+      "name" : "quarkus-arc",
+      "version" : "3.2.0.Final",
+      "description" : "Build time CDI dependency injection",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "efbb4b7b60f4a36c85cdba0dc402ca48"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "452f0f6dc0913f0dadc816e6ed71f34c5f544f34"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "78ad32b519b7e38f73f67a550328196c8b42587537db8140a9669f0841a707c4"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "56e9e940a7f9bfd72e742f863d1e63481de26674fd41f98a8d1e289ec26d7a5f2cd2bae4189881a73be9dbca47de7cfb145d8efa2e29949ee6d74324d93e11eb"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "8bb8efafca8b95ad3cea49d804c054d97a7a90fa4286257861e0bea382de28e548074622f843ee823ad3f84535ab971c"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "cde8de1473be98d42612dea9a97873aee86835faa5abb2435038ed9c5f8e09895e1d30c9124028612f067a9170b4f3be"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "d531c8355c04fc9476778b0b0b90062cdc4e9549ca384a50a309f9d41ef8d1a6"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "58640439318b87a4e4a055c4a59e1d2b8ad7407ca18cd92fb086a564cb09354700519c72fd3ec02ca788deeb8650e773c71577e8fa64759c4810e345a021aec7"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-arc@3.2.0.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-arc@3.2.0.Final?type=jar"
+    },
+    {
+      "group" : "io.quarkus.arc",
+      "name" : "arc",
+      "version" : "3.2.0.Final",
+      "description" : "Quarkus Parent POM",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "c325d421b773eedd798d190111262c00"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "239c124204c05a0ff7a1a1cea1f3228f3cc186a6"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "2dbc4d30128e0b59f7b31920a88cc512065bd16694a0740b283eed1b103c983c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "2d4d073462a6737be6425351626828ffb22a9170864e36928347633f6d0e75dbdaa936367841cd1b9f47b52b036d4ae98f91f162a41a6632533064daa7949728"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "e825a09404c320004c7e7d16c97a04b50f8d5bf6bb32319c0fe52ac492047ce947907215c610c4ad4d55eaab99b3062a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "4ab8db77d32c10f2b447d86705008e6927ccb0edb9e5f28c96dc02edd789fa253e0a191bbc586d25747ffcaef7d887a4"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "dc223cb0a1ba7604f7504fe5b9e32b9eee8e363e4ff20c7828f5f71d498cb98d"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "c6f10d65701d916315bf3a012f44ac64f850db92e0e0fecadea070fb20d0e4714e979e6672c769a972249f1117ddb8147d1af9abe8f5c1ac14268ac963ed4641"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus.arc/arc@3.2.0.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus.arc/arc@3.2.0.Final?type=jar"
+    },
+    {
+      "publisher" : "EE4J Community",
+      "group" : "jakarta.transaction",
+      "name" : "jakarta.transaction-api",
+      "version" : "1.3.3",
+      "description" : "Jakarta Transactions",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "cc45726045cc9a0728f803f9db4c90c4"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "c4179d48720a1e87202115fbed6089bdc4195405"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "0b02a194dd04ee2e192dc9da9579e10955dd6e8ac707adfc91d92f119b0e67ab"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "764ade8ba807682dcd1ec7382c35275f3d8ab09a03d5b45c48e732501190e2738269080aaf28aa8dd656c11ee84bfb7dae6953dd2768f2acecd3a8cf0ca4961e"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "63adeb3c5eb24ad0147377436b6e3208d5e97c0e800e0e1e4cb3ba92699f1b06034c2ba00e3689aa8f909ee96c432db0"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "dd0a253f45dac003d40ebeed7f38b0850ff4b08941d55db5b3bbf4c936f94062d23799729ff718c54a565de2482bfd3d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "d47afbaf1daba46c7aa107bf1b476857523738370309394958f96a2105686684"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "1b744b2d939a8d0a2bbd0be29c717af4a5e2374ca26fbb95a16df03aa55d2aa092e9314f20d5b080f02030ae1b70e4904ef0f8e1509680b9001153cdb7bc1934"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "GPL-2.0-with-classpath-exception"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://projects.eclipse.org/projects/ee4j.jta"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/jta-api/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jta-dev/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/jta-api"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "org.eclipse.microprofile.context-propagation",
+      "name" : "microprofile-context-propagation-api",
+      "version" : "1.3",
+      "description" : "MicroProfile Context Propagation :: API",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "14c55bb802683e780087d97fb9b92de1"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "aab6a415754137629e725a9927702a5cd68038c2"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "69ccc04487e87779d4970aa50c673cc34a9df080c1c0e8d8eab2e8b46f825cf4"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "11096a60b2e2f0b6d592942a51afbcb9394e022efa26181e7a62d8239daebfe88a3125de2ea40a27d2cd29bd642fc0eaba9c16ee0f31e176998b85354f768966"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "f7d218b27b0ca8763479dde412872c95bc29a4d433590d0a0e85ee59d8c595662774020a28bd9027be7a8d431dbed11e"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "88900eda7b84d4cb96bb3f306d9ec170688d58e80ebc15efe704f6b46fa68375c023035f5af68fe6b61ba4f22b890da0"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "54278b00912da6ecb74f52ad9fd95819680111027a296b2e73b393fa1a4d6358"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "222ac6d7e63a97505ad1350274672024c1f4ff0c678db6f590d5c5486b5e405e0445420c4eb9406fa80951833809d24c9fdcdc163c259d9b5a442a78b1c4a801"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://microprofile.io/microprofile-context-propagation-api"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse/microprofile-context-propagation/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse/microprofile-context-propagation/microprofile-context-propagation-api"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.3?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus.security",
+      "name" : "quarkus-security",
+      "version" : "2.0.2.Final",
+      "description" : "Provides, via submodules, a base configuration for JBoss project builds, as well as a derived configuration supporting multi-release JARs",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "a173f3913a07f40a1ec077347261416a"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "e4e6cd943feab4da384665ab0add7de712d7d522"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "fbb35f96cf199f410cc79c6654e4058e8dd5aea8b0b52471218447a535cd25d4"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "2a81654c851fc97fd5f8fb0f5e7ffaaf9ff0bcdcdcc48589dd056f4c18bc5d54a75aff3c82775c81c829db98369301d3cac313547e1361befa3c8de8406d038e"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "87953d4ea9cf3d06937919639ebbe4ebe58f98ece6a4609660a7083c434c474b2c362315b63d352717f0e96a4151cd75"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "3e2752e80d34191211fc987877e6154a8f5d5526dc7385354fda7226e26935c8ce0308eec1108bec92c52a37263543b9"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "25b45f5ea302843df0274e44b0671a2e6d679df59fcd7378ad35dad7b1271464"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "fcdd374d509ca83cdc945c02ee3988a532b0d031f7c1c22daea39683e15bf1b3f1b82ff64a5caa18c40fc21389fb85651db40561ce4eb09428b248424f68bef0"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus.security/quarkus-security@2.0.2.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org/quarkus-security"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.redhat.com/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkus/quarkus-security"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus.security/quarkus-security@2.0.2.Final?type=jar"
+    },
+    {
+      "publisher" : "SmallRye",
+      "group" : "io.smallrye.reactive",
+      "name" : "mutiny",
+      "version" : "2.1.0",
+      "description" : "Intuitive Event-Driven Reactive Programming Library for Java",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "eaa24ac6c0d29475ebb345610810f7ac"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "92ac583d1d5bc488a79d04b75ec12fe97ce7566f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "527c4c25dd1b0f5c6c110074bbded42aadb4a8db17a24ae8d2184246e483dfa0"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "3dbc7341c30dd0de23506cbe1792b67ca41c33b6faa063976d26654c1b72f554d87244ec1ec621b33dc07003bc36ca518a41d1bc173637341726018b60f3af53"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "a90fc8474846dbeca5a0efeda1f494d2e7a23de76aac472555b2b5676e2d5545af75787f08b4019224fa18fd4b7e1ce6"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "f4bc5192e40e12a3a3cc4d5a148a5b52a5cce1a6b56751f37448b0d79cdfefab873ccf02a8698d2780aa3de050b8be75"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "3009a90c8269d8e90c60bb2f345b7421d8ea0ae91c2d7c65da10dd9c55074b00"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "94f13a35932426e5240d2603cc8c85e36b0dd94d9c3abd1a28478c9a3b09a61f738c4d92c008280d53f506059d2d5f6bd99520acf57a83086e741ddf941147bc"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.reactive/mutiny@2.1.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://smallrye.io/smallrye-mutiny"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-mutiny/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-mutiny/mutiny"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.reactive/mutiny@2.1.0?type=jar"
+    },
+    {
+      "group" : "io.quarkus",
+      "name" : "quarkus-smallrye-stork",
+      "version" : "3.2.0.Final",
+      "description" : "Support for SmallRye Stork",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "8c4686c6b4f5311e362073c86e7f2ebf"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "5cc29aa24ae7f634ab39ac39eab9c4ad20a0065d"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "b7bc4bb07b0a6f5b66cf47b6d56b29ad7f641c176f3a1de7a012c3aa0d3d7e4d"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "a7c4010f4885fe2cd9eeadde311a2adc46a87a77bc465820ea52b224af40b57079293d76ce86e88df35581829a2042c15f7f568bee601ca76117207c834d603a"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "7e721c3a8a159868c399cb9b58bd8ae5d8b9b072764b51b4bffa73b0bb8984eee35125d3b5f55ae0878749ab519e5319"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "5a2d0c8474103019afcfbb2770560a67734efb5861fcae68a72270b2f9fec5ce1078cb8a034bd173e8e4f955adc45a52"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "0d3944650382e6556c5d7e5f48ad5ff7e7345ed313d5127a8c5400e66a212ac8"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "399447a83f99086c7433a80532dcfcee61c895bf7eb395918151c605d9843471188c805baac7b49e00a2748455d2d7cd0b1cf3aaac73b3bf128fd3aef8d6cb56"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-smallrye-stork@3.2.0.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-smallrye-stork@3.2.0.Final?type=jar"
+    },
+    {
+      "group" : "io.smallrye.stork",
+      "name" : "stork-api",
+      "version" : "2.2.0",
+      "description" : "Main Stork API classes. You are likely to need `smallrye-stork-core` and not this module.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "7d7a0fd6079b4f49fbff4fd278abda8e"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "6690da0dd7a4eb6a427a97ef5a5a7eff155c1cbe"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "04c60074dabbc578462e27630c8914384fd0c5c7ba22bf644c48ac357cc79630"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "a6cbe9be18dc518caa1b7ca9d0b5cbdad9c513be29d560f1dac38354b1b6681d7ca6c0dc4dcbf26c4f51cb23202bdd6ee06d95c658571558a624c0674c588e39"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "4cb5b8568c7a7f01a0d5db1442334b975775abdd75aada03218c1b385a4a343d9a7c0c81035498ba28834a18ef2a9ac3"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "2ef0fe47111f805ae5819abce15d01dd8b0304563ff77fb5f2dfda1de445fb380c0c3c9efc3865ad2cbfbef5a0b4394b"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a76a37c4e2538940f54f60b6d566f14e00d672ae98b9c2b6316897ea2b9ad877"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "ab61c474a3d75c40628cbd50b9c0afc4cc9935afe39478a1d0963a39dfa9670493effe5bdc98a5533f9a6016a1c79348ddd0a456cf650870192d67b725c4b52f"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.stork/stork-api@2.2.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://smallrye.io"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-stork/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-stork/stork-api/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.stork/stork-api@2.2.0?type=jar"
+    },
+    {
+      "group" : "io.smallrye.stork",
+      "name" : "stork-core",
+      "version" : "2.2.0",
+      "description" : "SmallRye Parent POM",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "05267f28ee7ba1e30cd49c6db8faad0d"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "ace83334099ad9b12507f7bdfa3242a03f3a61f0"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "f521338d693ee36eb2c9ce500300b6c2b8007874725df8f12a9fbb0e52033a2c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "1d1dd515632df0a92e7c70880e62cb113df53dd5022bba778211d71b231b2191c61c194c61cb0a2ffa429ba33b6b18d603873b1168b9913afb10fe20a0a79bb9"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "25b7099da0b41a915dce765522879376338198d47c56b8e9754ed43f2eefb0fcfd4b827cff2c00d0af068328bb84030c"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "6284b9a1532ffa4ef78ff87b5082a926a2afdd3fbccf81969d20a40fa96b1d5145cc96d58f2fd1a3981a5d74c8432107"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "2da6e2fcfd1317eb8d98c7bcf2bc1ab65e3130feff1b95ad8fa8d8570ec2a0f1"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "00254f1b09ffbd4216bfbfdf73ff14e8d669c3a906d8a42095ab2d90ffca228cc36676e72e95fc68409a7b62dc446bcb5e553f9607ecadc777031d0e28df2ae7"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.stork/stork-core@2.2.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://smallrye.io"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-stork/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-stork/stork-core/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.stork/stork-core@2.2.0?type=jar"
+    },
+    {
+      "group" : "io.quarkus",
+      "name" : "quarkus-grpc-stubs",
+      "version" : "3.2.0.Final",
+      "description" : "Build parent to bring in required dependencies",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "94f4a6cdc74797e00f50ba21381a722a"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "cd036ebffe1ba619e89b5e43f5013e8fcb99919a"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a538b97b2e09a8d82ae7a7847ed457ab1c640bedd2fabca88d17240165ec9176"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "6049f9d0bfd0959ab68f1293202e523bb439129dbe7661a8915e9d340324708f43c1768c8ffd44d05e690ba84bce43a0d990022a49dc6307dd624e34c1c114d2"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "bbaf3aede00c23ec013c012b20a39539f41ca06eb0dc15c4f66b755ef85b91172a298b27f178935205632da2235b217d"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "9fe146ab4d0e54a730b282eb721b1f52e572169a0bd65a6f5434e6ebd915664247ef74154857fde95cebb3323cdff159"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "6a83e00d93f38b4e76e0ec9c40d42b798c9e574285433c5961abfb63593c2390"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "03a2842e372c4a912e786281569d797eabc5c196e5692283231c45890dbeb6bb14f0fef597c02a654d5cca6646261a5323f300e99b6a5ed243469b0f72c76a48"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-grpc-stubs@3.2.0.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-grpc-stubs@3.2.0.Final?type=jar"
+    },
+    {
+      "group" : "io.grpc",
+      "name" : "grpc-stub",
+      "version" : "1.56.0",
+      "description" : "gRPC: Stub",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "d1fe4b2ac1f2692c67b9b78ff0e0714c"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "46e5bc1caa5fc3ea50aaf386658a1c2bb57d84c8"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "4808c5f63233b2df2c2fd2ce14b8384ce9b0a367f7842e93b1e5b9bb342cdb0c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "2927fa6a626e3195b8a82cc387a7dd01b99e843f471d28179aca674294e3a2846301497c3eb537c6ae38c0e745319640db57d04341572aa5bd0722f2c72c289c"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "b359ebbc942aee9339a2c3655805d1b81d14e4519c1d75c110bfe58a12c99d05a437696ddcb90890867d25570b977a58"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "0ad7aba0bd3242b9c6e33ee5907e3f8f97ed0432adf53c3572b414f89032bb009f13e617abe6cd5be2de5d490095bb74"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "3ae0fbecd8d8159edcac5ee011513557964a7932477059baa9d8635d9b9fdcf6"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "dddf107ef49ab7456f9f6144496f0f0a5daa1e7ab0c65ff23c9b81cfc132c1111ff390b4d96da57383eaf5a5ab8669b786d14456fa730a916847bacc26bc82b9"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.grpc/grpc-stub@1.56.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/grpc/grpc-java"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/grpc/grpc-java"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.grpc/grpc-stub@1.56.0?type=jar"
+    },
+    {
+      "group" : "io.quarkus",
+      "name" : "quarkus-mutiny",
+      "version" : "3.2.0.Final",
+      "description" : "Write reactive applications with the modern Reactive Programming library Mutiny",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "267f9aba93b6c4b9171095ff0ca21b16"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "7388915d2e1fc04535efe0ae79a9ecf49714c4d2"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "8045174f405593eec4f185eab054350e75723015c03bd121c01b00bef85e5a1d"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "6c5ac46e6c2a12ecfd323032a0051215aca14cf49ffa48539944e0b4692ca48392b97e9722f5800428455e45dfc8ca8c52f2be8684e7f701f250313774961465"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ab56585028f83e14854e5a04da2589514af8ccbbb2cfff2fb91e0f664d9626f88df6311e885f4b2ed14c90968d8ebe5c"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "55d42f3b57793c38346ace30974d62a040078288c03bf7a29208d6aec9cae93804f145e8a9ecaada4adcd0e19f920028"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "8b6346b26ba8526035269ea4fdf515b4a426c1a3bef1450a2ccbc1e04449b53a"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "d0b8de2d3c42a35f487ef5b09a971df8d2e1b84c93825f6d3eda5f6237502df8c2cc6e0d517861b1e3609758c385926fa9a5c1c466bf14fd67c6c851a203e74c"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-mutiny@3.2.0.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-mutiny@3.2.0.Final?type=jar"
+    },
+    {
+      "group" : "io.quarkus",
+      "name" : "quarkus-smallrye-context-propagation",
+      "version" : "3.2.0.Final",
+      "description" : "Propagate contexts between managed threads in reactive applications",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "23c29b34f04d3cef6e90a6fc48f6a56a"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "2f669f8f885406a0b30306430f948f66f81b0a24"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "329994e2f13651cafea596417f16c3b815f09e7ca10fa86e2e6c726e5386d96f"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "2d2f7d25d2e38971653943fc348f40ca1a2a213372852b9b7831b2bd549a08f2ddb37ee5b54dd58e9a1d687cfd450574acafaa42e5f6914eb6af09e9854bb9eb"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "253b1215d04d0002f41f694cfb5a660f38245a9b43ee63a96af2b76c31160cfb8d3ae29d4a660f0793515bcc89a878b6"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "71ad87c4d2a259704d8cff5fd790708fc9184a6514fbe172fafa30332a793ed4c3093f8c6901f3986074d86ba72361e6"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "4426cb44e91a6598d62ec8dfd62d271da1d56c5ecdf102c0a59ed3d7bd772186"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "fc2bbdec7cd3f7813033e9122b6eef8d21848fcf8ea35fa9965d6a547bdba3b960acd71571e98462a0f1bab5ccfa696b0635b1b1f32b38a67f014e4cbc440b7f"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-smallrye-context-propagation@3.2.0.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-smallrye-context-propagation@3.2.0.Final?type=jar"
+    },
+    {
+      "group" : "io.smallrye",
+      "name" : "smallrye-context-propagation",
+      "version" : "2.1.0",
+      "description" : "A pluggable library for context propagation in reactive libraries",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "f911c600f32133d54d8b70fbf31a959f"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "1da1ba2f32c940b8b1d18bb2707cbb496498c16f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "9ae76ac5a2025050f99e0d41c15bfa7957d8a84458aad33b79a370ad06271c1a"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "8df0d1c2633362d2d0c0814a847532ed6090e2545ebf31b949c5ee81ff95e142a6c8e8e34676a57402b3f6d21df8c21d2549684d718a627d70b6afba60d83142"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "2a5f0d09ec407deeaca480a13fea1aa545faa71fc8669c6be7bb95e09173221548473d2fc7cbb0dded32cb204d7a342a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "6affad1327bd6f288a929db880f7cf4e2bbb92bf2a254d58b798e9cc3ef6247e8906d5fc613bf085c0baf9e8e060b57f"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "6335078017b82f797d1beb4200d1b725150c23f81eff9299b837929e9e3cf400"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "f7f93ee4477b45c7cbeb09c092f51aab6dfc1e0c7e3bd1d2958efca3187eb05107a17f46eea38a885a7d5c38be95b84658870cdb7788715608215e41597d21f8"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye/smallrye-context-propagation@2.1.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/smallrye/smallrye-context-propagation"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-context-propagation/issues"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye/smallrye-context-propagation@2.1.0?type=jar"
+    },
+    {
+      "group" : "io.smallrye",
+      "name" : "smallrye-context-propagation-api",
+      "version" : "2.1.0",
+      "description" : "A pluggable library for context propagation in reactive libraries",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "4cb49cf01a874389d71205d913d1ddb3"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "0e8004da351a0da60fdc5c6a2d8f0a0b45320335"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "176ff216c5723d0f9a18db303dfaedcf3b988b4efb0a7e0e56ed8b77561f2c89"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "cdc4ebc51560355fa06d027271b171bcd5450a0027f25fe2d0a34a80dd6949a6a41b0ce1990f6f0599cb6ad19be45e864dbc5fcd470076bbe843e84294c9479f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "0ab809ebdf6bd4a923484832f04d9c686c3676213d037271124cb09f2e512ffe2ad15172668c23262504968e374eb571"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "4601e7bc868a6c7ddff325c6736d4fa7baa2df4cc2b15ee4ac470487050c6b27d4c18ccdda5294ac010f67024858f5a8"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "444f014101664ebdc50d63eb9ace287a7837f9bf4b98b3f72f610e9598cb21ab"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "3e250d639a47986fcbfe3eab61a7420dfbcd7d510919243a11b49938a1411890e813cc78841e0964855b7ee642f138c6bf1cdc906b7401fa241135b51ec7b1b1"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye/smallrye-context-propagation-api@2.1.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/smallrye/smallrye-context-propagation"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-context-propagation/issues"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye/smallrye-context-propagation-api@2.1.0?type=jar"
+    },
+    {
+      "group" : "io.smallrye",
+      "name" : "smallrye-context-propagation-storage",
+      "version" : "2.1.0",
+      "description" : "A pluggable library for context propagation in reactive libraries",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "329bcd587112bdfe3e4b437580c3faeb"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "b37b1c4a73239085f8212d2b8c3cd463b20c3f41"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "05a149bc0c4a57bdda6f3285e45973d64c60f3a30261d603d1af212f2fc6775b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "1e9224fdcf9ddb3a759b7a5d469d45fca3e862866f169bd3da0cf9a358fc28917cdebca7af3df12958234d9a6402c446a468c70e46a0fa4814f3c225a7709022"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "33b70ee6af534ed3e5d9cd2ce8cd56657231662b48c22a59ae4fb4ef09f7ff358326e19a72cdc4babb962ec104141653"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "b5ad8e537ed43aac2e71de3df632e52da2fbc2354cdd42cd6377067be6f55a68dffba747b0256efa555f550bf8a5b170"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "b7f20fa6c4fb2c9415056012b0e0fb7452589dccb3fb71a78645fb2835e35888"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "152ee3d930cedb52e0c6b31b2c3b4032c4ccb623808b11d3c1a37c33e3b432152ccc5e88e068caf8a913b37085e14d62fbf6a1b6ec1994307ba1af9137455ca0"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye/smallrye-context-propagation-storage@2.1.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/smallrye/smallrye-context-propagation"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-context-propagation/issues"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye/smallrye-context-propagation-storage@2.1.0?type=jar"
+    },
+    {
+      "publisher" : "SmallRye",
+      "group" : "io.smallrye.reactive",
+      "name" : "mutiny-smallrye-context-propagation",
+      "version" : "2.3.1",
+      "description" : "Intuitive Event-Driven Reactive Programming Library for Java",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "d595d9ce1d1b59864e415268821b6be8"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "3e33d2c0870c59a59d8642c2b7bce8a418ed0e98"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "7d148eba93bd86073a60396548bfa3c42c21a19fbad6b98150366004aa008930"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "203a9ce137b14988c2a74d351844d66b5d4e045014604a4ef565642a806ee470b021161271adc76a86eb7ce6c0ba4929f865b1dcdc980417acd818865cd9266a"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "6af5f8ac109a5f06ac9c7f7680a71a425d02914fb68b5711b2b060b5ab32fe3b321159a7a9530ea328028fa53168b9c6"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "094518f4ab068ff890bea102a581b1c6464fb722c87127fad6e186f474357e6ab5673b753821af109f40bc639268004e"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "c8cebecc4dc31b161af0534714ad9125307875032ee6647e3c8c4e441c2a70b4"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "84bc4eb8e24af0500bfa477c73d38ffeb5f5506eebf032603e4018dc3b8e06fa25e2e868187a750c73c57ad6eb1957f1b949b591374b0f34c1b0249039ebb232"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.reactive/mutiny-smallrye-context-propagation@2.3.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://smallrye.io/smallrye-mutiny"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-mutiny/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-mutiny/mutiny-smallrye-context-propagation"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.reactive/mutiny-smallrye-context-propagation@2.3.1?type=jar"
+    },
+    {
+      "group" : "io.smallrye.common",
+      "name" : "smallrye-common-annotation",
+      "version" : "2.1.0",
+      "description" : "Common utilities for SmallRye",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e0c0641720d8b40589efa213be5c90c3"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "8e62a28240a52ac80d737262446a4d62de70bd65"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "b9c6d9ac1887f645259d8d0d6ff4755bc17d961e2e02e83ead6f699ae3d6f8c7"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "450cf4b194918ddbaa832e32494ca08f426f5e807135dd3e540b94e2d73155defc435241dff2197a19ee72721d2ff66ac9218989c791760a4ce0a3073bad085a"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "76ec2e9d301ebb3521da8f8fa5905ed1749ed9c7c0253d5c6f9ad16b86f0e97b11e5398e3f1be922ba9549460cc9c27e"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "4c1104a942aa7be188eea036cd7a606850b5f762b1b5588e02f52b51c9489ab77d864041455933f2cbdfff9717e4f1ae"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "e848ab15c694874657d262abc4309c500d5d20863b093c21a9ec3cbbb61068f4"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "7f75292ddf0f41dd4f3dac6de590ddfe3a4c5f8cc01248606a06f83b28a606611d4c1db7483d00649e5a8636309563711a0b5d64cfbb0a71b1d0041d386a89e2"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.common/smallrye-common-annotation@2.1.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://smallrye.io"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-common/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-common/smallrye-common-annotation/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.common/smallrye-common-annotation@2.1.0?type=jar"
+    },
+    {
+      "group" : "io.smallrye.common",
+      "name" : "smallrye-common-vertx-context",
+      "version" : "2.1.0",
+      "description" : "A set of utility classes to ease the usage of Vert.x context locals and duplicated contexts.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "818039fd15f089ba75d7921f5bf03681"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "66b25435248dafd69526ef4f48d6dd9d4307f9a0"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "146b6b83e5c3a2746b382e929e0fe783d5ac4f735f364518753c48e6d8466ca1"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "e205cfaf530fa6cfd9333f9d87e88b0b1fc8b030abcedff8462f7f5677dfb4d55a226ceab3f09d9b1cdedb8f4af8e33e4870549a26203551d4108e8d53302c02"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "b8928c0cb32e4875f5e778b60187fc7a7683a4f15240acf995f4be1549bd784e415bc551a7686def77e8b50126e6364b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "2311a82ba4b5eb38b84e96c95142f40b31ddc904cf6fc9793a6ae1c85227e455283e924d17384c6e0ee548290c016f05"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "519e51c5206919157919c729aa340b22a210cf0f9abbcef7a77049885a95b955"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "844f1d8c2d4b32738545df750129f2846e4a5e4c67c1cb14bad19751e48dd2deb718cd6b9dc5d70260542c1fdb0b70de4424cadadbd8babfecad700d2278434b"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.common/smallrye-common-vertx-context@2.1.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://smallrye.io"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-common/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-common/smallrye-common-vertx-context/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.common/smallrye-common-vertx-context@2.1.0?type=jar"
+    },
+    {
+      "group" : "io.smallrye.common",
+      "name" : "smallrye-common-constraint",
+      "version" : "2.1.0",
+      "description" : "Common utilities for SmallRye",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "8aea738175a23f2649b6e3e2e9034116"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "1e630cde594b2ce693ba98320c0119d5f05dd564"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "169deb26ae8c4fd01ed75bbad7d92d4a30d29d7c5e9a3ca713f0e08df62887a6"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "5ea9be36cae4a8f2578abfff747f5ddd3b772348613c5c9c742db6809fa7ffb8d625903b36a0a3eb991a72a1f7cb483078ffe574306cc460c01f7fcdd1d3a326"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "eb2986d8ac2556c524665b9ee2ed84dfd4035db5ad83a1704eda00ba8ef480425df8076d4e1cb1f91fe8052917af99e3"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "041f0bf26ef06b3a288c8a1bdd856261bbfb38f57ce25739d7c60ce05141b99e1b52caead3110f156ca9f8b33eba6582"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a0f513e9db9da011dc6426ca300ee5d9e28cedb294a3e97786a51ef19204ab9f"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "e1cbbaeabfc11df3a66783e79f5b937235ab43ed38eac7d5208859f3590989041640f9d7703c1f610942733b1a0680827ef3ac15d2f44044ef7dc36a8df7ff27"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.common/smallrye-common-constraint@2.1.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://smallrye.io"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-common/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-common/smallrye-common-constraint/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.common/smallrye-common-constraint@2.1.0?type=jar"
+    },
+    {
+      "group" : "com.google.guava",
+      "name" : "guava",
+      "version" : "31.1-jre",
+      "description" : "Guava is a suite of core and expanded libraries that include utility classes, Google's collections, I/O classes, and much more.",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e37782d974104aa3b0a7bee9927c8042"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "60458f877d055d0c9114d9e1a2efb737b4bc282c"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a42edc9cab792e39fe39bb94f3fca655ed157ff87a8af78e1d6ba5b07c4a00ab"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "532664e3dd33699bdfb296e355bc58fde77edc019c10f464ae49fe2494a68fd25d1623a9c86bc72830ca9f1354226366ac6f3c09d77be952641e971386a4ebbb"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "829ba1c473782158d43a0e56c932b45139f121a504613b27eacf6b0774354e52c5eccaab5c2da3753b5686b93f0169b4"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "55f70ee4afad92540faa9d260109c00190e6d1bbacf10b22e52f599103284c1a8b2a2043d8fafbe1309245290b5fe614"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "dd534fb7df6b380d8701290b0b0c4e388cf42f8179a436c509c0899afde91e5c"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "617288cc45858588e0626edd21382d38b87cd0e6c78221e3a1626f579d5b4acd4adff37b72e3e51c73e91132f43951d12369624dd515f87bcc0c54213db43ede"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.google.guava/guava@31.1-jre?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/google/guava"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://github.com/google/guava/actions"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/google/guava/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/google/guava/guava"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.google.guava/guava@31.1-jre?type=jar"
+    },
+    {
+      "group" : "com.google.guava",
+      "name" : "failureaccess",
+      "version" : "1.0.1",
+      "description" : "Contains com.google.common.util.concurrent.internal.InternalFutureFailureAccess and InternalFutures. Most users will never need to use this artifact. Its classes is conceptually a part of Guava, but they're in this separate artifact so that Android libraries can use them without pulling in all of Guava (just as they can use ListenableFuture by depending on the listenablefuture artifact).",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "091883993ef5bfa91da01dcc8fc52236"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "1dcf1de382a0bf95a3d8b0849546c88bac1292c9"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a171ee4c734dd2da837e4b16be9df4661afab72a41adaf31eb84dfdaf936ca26"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "f8d59b808d6ba617252305b66d5590937da9b2b843d492d06b8d0b1b1f397e39f360d5817707797b979a5bf20bf21987b35333e7a15c44ed7401fea2d2119cae"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "67659dbd9647ec303d7f15128dc9dba19b98fd8d74758ee3b602451e32c855e236ccaafe08edf4bbfa245f981268440f"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "1460875f0331c5fa3791772a6a322a7db180261bc2adacf7271df1fbf3b088a587a755a604c039982cb593c5cfc1f101"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "ea86406e75fcd93eafe3cde1b3135ba485f1bb9b75fed98894a0bf1f0aee04f0"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "52ac0f487ab5dd27c9f2e54fd1d84c7a620cae9d49be4072aa2b11501787bf4391ddaa13d02eccdf19e8eea46aecbea5f6064b26777c1b836108a280652e04ac"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.google.guava/failureaccess@1.0.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/google/guava/failureaccess"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://travis-ci.org/google/guava"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/google/guava/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/google/guava/failureaccess"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.google.guava/failureaccess@1.0.1?type=jar"
+    },
+    {
+      "group" : "com.google.guava",
+      "name" : "listenablefuture",
+      "version" : "9999.0-empty-to-avoid-conflict-with-guava",
+      "description" : "An empty artifact that Guava depends on to signal that it is providing ListenableFuture -- but is also available in a second \"version\" that contains com.google.common.util.concurrent.ListenableFuture class, without any other Guava classes. The idea is: - If users want only ListenableFuture, they depend on listenablefuture-1.0. - If users want all of Guava, they depend on guava, which, as of Guava 27.0, depends on listenablefuture-9999.0-empty-to-avoid-conflict-with-guava. The 9999.0-... version number is enough for some build systems (notably, Gradle) to select that empty artifact over the \"real\" listenablefuture-1.0 -- avoiding a conflict with the copy of ListenableFuture in guava itself. If users are using an older version of Guava or a build system other than Gradle, they may see class conflicts. If so, they can solve them by manually excluding the listenablefuture artifact or manually forcing their build systems to use 9999.0-....",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "d094c22570d65e132c19cea5d352e381"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "b421526c5f297295adef1c886e5246c39d4ac629"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "b372a037d4230aa57fbeffdef30fd6123f9c0c2db85d0aced00c91b974f33f99"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "c5987a979174cbacae2e78b319f080420cc71bcdbcf7893745731eeb93c23ed13bff8d4599441f373f3a246023d33df03e882de3015ee932a74a774afdd0782f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "caff9b74079f95832ca7f6029346b34b606051cc8c5a4389fac263511d277ada0c55f28b0d43011055b268c6eb7184d5"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "e939f08df0545847ea0d3e4b04a114b08499ad069ba8ec9461d1779f87a56e0c37273630a0f4c14e78c348d3ac7eb97f"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "1f0a8b1177773b3a8ace839df5eed63cbf56b24a38714898a6e4ed065c42559f"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "6b495ecc2a18b17365cb08d124a0da47f04bcdde81927b5245edf3edd8e498c3c3fb92ce6a4127f660bac851bb1d3e4510e5c20d03be47ce99dc296d360db285"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.google.guava/listenablefuture@9999.0-empty-to-avoid-conflict-with-guava?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/google/guava/listenablefuture"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://travis-ci.org/google/guava"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/google/guava/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/google/guava/listenablefuture"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.google.guava/listenablefuture@9999.0-empty-to-avoid-conflict-with-guava?type=jar"
+    },
+    {
+      "group" : "com.google.code.findbugs",
+      "name" : "jsr305",
+      "version" : "3.0.2",
+      "description" : "JSR305 Annotations for Findbugs",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "dd83accb899363c32b07d7a1b2e4ce40"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "25ea2e8b0c338a877313bd4672d3fe056ea78f0d"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "bb09db62919a50fa5b55906013be6ca4fc7acb2e87455fac5eaf9ede2e41ce8bbafc0e5a385a561264ea4cd71bbbd3ef5a45e02d63277a201d06a0ae1636f804"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ca0b169d3eb2d0922dc031133a021f861a043bb3e405a88728215fd6ff00fa52fdc7347842dcc2031472e3726164bdc4"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "9903fd7505218999f8262efedb3d935d64bcef84aae781064ab5e1b24755466b269517cada562fa140cd1d417ede57a1"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "223fda9a89a461afaae73b177a2dc20ed4a90f2f8757f5c65f3241b0510f00ff"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "3996b5af57a5d5c6a0cd62b11773360fb051dd86a2ba968476806a2a5d32049b82d69a24a3c694e8fe4d735be6a28e41000cc500cc2a9fb577e058045855d2d6"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.google.code.findbugs/jsr305@3.0.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://findbugs.sourceforge.net/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://code.google.com/p/jsr-305/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.google.code.findbugs/jsr305@3.0.2?type=jar"
+    },
+    {
+      "group" : "org.checkerframework",
+      "name" : "checker-qual",
+      "version" : "3.12.0",
+      "description" : "checker-qual contains annotations (type qualifiers) that a programmer writes to specify Java code for type-checking by the Checker Framework.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "ab1ae0e2f2f63601597a5a96fca8a54f"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "d5692f0526415fcc6de94bb5bfbd3afd9dd3b3e5"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "ff10785ac2a357ec5de9c293cb982a2cbb605c0309ea4cc1cb9b9bc6dbe7f3cb"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "ff20c424e130c31c30b4f4f5b4374f8f98f94ddae2b123f3c213f147be6b3de57854ee5651b02dd97d352c1c1df2a8bfeef73d5307a71372f46a6002eab24d78"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "60641d5967c60154359437cf49d8b0c14e7c1d876ab1fff4932590b19edcad0e65975299004ac896fb190f45b69ef1a1"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "aa56f81cc52d6fa2bf40be155584ea7bed253b29fa9d7aa9b56d898ea01909b217efd676ceb8c7c913c4d800bfee7529"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "85ce7342830164963b1cff7257c1e07aec3eb134ba4ff7102e77de8c33191c87"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "29ff1fc98ce64a52fc15796f127b5b100522ef88e15c5e129941c4954a3ef1b51a3059c131cb36ba4838c5ab76b2e0f2ab2dd4e9f6edba0ec8154c450c0a2130"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MIT"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.checkerframework/checker-qual@3.12.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://checkerframework.org"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/typetools/checker-framework.git"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.checkerframework/checker-qual@3.12.0?type=jar"
+    },
+    {
+      "publisher" : "Google LLC",
+      "group" : "com.google.errorprone",
+      "name" : "error_prone_annotations",
+      "version" : "2.11.0",
+      "description" : "Error Prone is a static analysis tool for Java that catches common programming mistakes at compile-time.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "656ad66261b7e7ea472ed0ffeea773ea"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "c5a0ace696d3f8b1c1d8cc036d8c03cc0cbe6b69"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "721cb91842b46fa056847d104d5225c8b8e1e8b62263b993051e1e5a0137b7ec"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "defcaf30b7def5071243f3982d0d81c47c05b1a95c4d6143b3af86451e97c212c8d620d7220784e541fe8ee95f7fc59452fa6392fa37dac2d5705bfaf06105ba"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "92221cb62c44dc982a8e9c54b99a1c75e0e4c48cd2f03b3272badcd03ab1b8bfc8bcbbe426a8d08074edba69b09a2b79"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "545c6c45a970b5ac7eb236b0d5d4b98e48e9a36336d8052bac36b409a7489a3d6d68f5a7bb58cfb21189bdab477d4b92"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "dd2ca92808ddd03f50e3776b6e9aa86d92bdbf170ebe06d47e7c45940b435739"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "2cdc44a85ce2fb11e54bdd6487978f181f8daca32c40895b252f4be352f9a631e35bc0fabc026216365a05980f4548b2d59dc737b0d465e0005c0a1f325e281e"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.google.errorprone/error_prone_annotations@2.11.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://errorprone.info/error_prone_annotations"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/google/error-prone/error_prone_annotations"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.google.errorprone/error_prone_annotations@2.11.0?type=jar"
+    },
+    {
+      "group" : "com.google.j2objc",
+      "name" : "j2objc-annotations",
+      "version" : "1.3",
+      "description" : "A set of annotations that provide additional information to the J2ObjC translator to modify the result of translation.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "5fa4ec4ec0c5aa70af8a7d4922df1931"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "ba035118bc8bac37d7eff77700720999acd9986d"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "21af30c92267bd6122c0e0b4d20cccb6641a37eaf956c6540ec471d584e64a7b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "51ea975179f809cb260751d11a513881b643bf016d15949bcb63b57d3c8868a2197e0620ccbaa5739e032797ec6faa3aa6d64606e999fce32930314780ca4115"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "d2a54e4bb17793a98f85fb8f91138cd3b3d311385b7fb2c09d05c3112d42218a6da29154ba184f00031919548022aa71"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "8ba512ee47d36d5712335849e8f0fae21498c983c48fc2b4749ac7dfb4eeddf75dd51d21366667f90d6414db032a7b5b"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "e97bbe4e1ac9f9785ad0b81fd29fc9c6b0d9e37acc6da6d0b31ce9e6da072664"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "864bc6181c8ad8372e0a05ec3b0bdebc876571692331d3519e19df54a21ef333e992fe5c4e84759f010cf0657f9ea1c435bea8f103735ec3dc9dd31493e7d4a6"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.google.j2objc/j2objc-annotations@1.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/google/j2objc/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://svn.sonatype.org/spice/tags/oss-parent-7/j2objc-annotations"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.google.j2objc/j2objc-annotations@1.3?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.undertow",
+      "name" : "undertow-servlet",
+      "version" : "2.3.6.Final",
+      "description" : "Undertow",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "1dd9d9a1c8949b20196279716c57dec5"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "c2c9ae07411179e6dfb9863b48549b315c66d815"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "8462fa6d6645b79d154685b7d876ce49d094f19b4f255824db024e1b002da0d4"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "58e703dbe96df5e68c8ddd3a82d491a4d3bfe0ac72f63abc3493d582b6b61dc2fba0405484f8b503e1560f76d7490dd5abd41211ace3c584bf5753f68b96040e"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "a9575ca99e517a57587cfeb41d3d0123c9a7e5d37f8e53a51279b04b656e9f3cc6d2e5e7006fd32d0f413cdb4376c375"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "0658be466ccdaec25650fa4e4b37382b55e41456fccc794360c15426f3289e82a389b4e56ad7382168e828a5bd3a9817"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "9eef15c1dc7a85745a7d047c8f159d466d1eb2cd9c4dfa091b0baf81b27b152a"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "7adeaaeaa641b729266d799c155d7d92a9bf4bbe62e99d46d130ff8cb5c5a8b55348484ab162cc1f3dd410adbb0d7d852ff7d0113c1ced0c89222a0961e55e35"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.undertow/undertow-servlet@2.3.6.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org/undertow-parent/undertow-servlet"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.jboss.org/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/undertow-io/undertow/undertow-servlet"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.undertow/undertow-servlet@2.3.6.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.undertow",
+      "name" : "undertow-core",
+      "version" : "2.1.4.Final",
+      "description" : "Undertow",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "9a9e44ba58abc46ec225c79e0593d628"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "72382918e565a40b2e1f044a3b3c4a436f0c5342"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "41306e9574a13c09c9c7f6bc9fd1c4da7cf362f7b8c755a87d042c8922784eff"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "9548a00489c31e3a0afac3e27d4c211f841ce46bb0086112853cb90b09b6e1c103ebeab9e3d1b1bf88ef4ff17ed928be5e79537fb56319c4080abfa4dd4d80da"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "5406de2c5ecffab949e4696860189ca29b0965d92a24d3ff45aceea294432727f2a5a030acbd1a80224d435271f51454"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "5cae8d8c2b447a4e469968f5118bd712e97fcdcf3444f505d26608fa37014526f20a6491123513bb97e2141daaa3818a"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "06b466506c2f4448241f4b291984aa4b5ca75c512d7d57b5d9158a40b6baa0c3"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "ff4899e4da5818a89732a41d095265aa8ca38ad07e5ffa2e60afd67ad8117ee314a56007c88e1ee764b1930ed69463fe40a5f32d5a4c5d9ab9ad9088f998d769"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.undertow/undertow-core@2.1.4.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org/undertow-parent/undertow-core"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.jboss.org/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/undertow-io/undertow/undertow-core"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.undertow/undertow-core@2.1.4.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "org.jboss.xnio",
+      "name" : "xnio-api",
+      "version" : "3.8.0.Final",
+      "description" : "The API JAR of the XNIO project",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "d98978e1a3140c06a5e71030136325f4"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "e2c29acf42ac6f42c34f0b74ba089e3f3d1b2394"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "543a79d5cdbe3237ea22ca44b85c65a5d068046d7b88e6bbab6f2e72d6b63810"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "eab8904c5e2f6071f076e5f68fc7520fb4e9f292df2cc03be4ac7834f52994e9f539b52be7509280f4fb49a4ded185732e8a50ffd3417e39b540d508db34ac5f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "c91bc87af0f4dc1e8fa5cd97baf9e07900099fddf21c79140ef20815c63db6d1258589a6d5d98e30fc1ab5522191693e"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "2ae4e1c7ca16232af0f070702c904d4dcfe3b5dc32b8b15e8e8e497a2543a55fa788cf850f00148895909dd965712d22"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "5f858e5a4153253386b328061d6b111a285c1deecc08de2fc1dd951ca4b2a1ca"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "8ffbbbf74772f6677bc67c13339571625ba302af9978eabae7475b77618f09c5cdbce8d4660693a993d9d81475cb8ad4f0d192f245b9d31555422bb07d4b9341"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.jboss.xnio/xnio-api@3.8.0.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org/xnio"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.jboss.org/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/jboss/jboss-parent-pom/xnio-all/xnio-api"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.jboss.xnio/xnio-api@3.8.0.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "org.wildfly.client",
+      "name" : "wildfly-client-config",
+      "version" : "1.0.1.Final",
+      "description" : "Library for supporting WildFly common client configuration",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "77f13d40c0fc70d05b48d43ac8ae2581"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "2a803b23c40a0de0f03a90d1fd3755747bc05f4b"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "80a4e963ce94ebb043ecb0f2c0e77d327f23dc87d81350b863752eedfa2c3bb3"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "3f442478c57f7dfac7039f6c7ae014bb2d45cdbd690ee631a3349edbca414adfe1984d065d1439f9b1546fa15fbd032c3a6bfe008f1ad50eef74201467b9f55f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "fd6285cf6398f0395c538873c4e52292c467d5f752f47fb8040224b37ec4e39e410136bf040c33ba8b42b3d6cda58a05"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "a3f92b65c9914eba7d47ac858ff37d512852691df29d68dd01587e254dd370404a3f0243adf7821a677f1b88904124c9"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "6e6e537598960954ea18998ed44b696a21a662bfd5268c58dd1fab739882ce34"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "94f46f167853b771ead83d87a93e826512575cb5ef505b841b28d4d818a39f5fe0cbf8b9b155719b4b43569a6fbc4f2c36ab14bfca8fd43ab64963a547fdce74"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.wildfly.client/wildfly-client-config@1.0.1.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org/wildfly-client-config"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.jboss.org/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/jboss/jboss-parent-pom/wildfly-client-config"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.wildfly.client/wildfly-client-config@1.0.1.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "org.jboss.xnio",
+      "name" : "xnio-nio",
+      "version" : "3.8.0.Final",
+      "description" : "The NIO implementation of the XNIO project",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e1007def77248737999a8dc4b3f77dc5"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "90c57dcf7f8c846b4da331d0e6e048c39842c92a"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "4e1a547ee83d62963fb1e9439c9fc10f353f26961f20f986e0982362cab2cdfe"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "7f2c53222caf40793b1c956aa08ff3316a86577e6a79274050bcdf700b68546397b286e3d693c1b3036fe9175f54f76816cbf6a100ae67f9e6c20b4ca028e56d"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "e6af5fda2f1a027fcf86df88083984e33b1ebb3cecbbfa7f5faaa1f70da2966102c41f24049a00dbdba822d820708cff"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "1ed672037e1abe4fa67be98c7f9075c3d496e13131e6e6ce3ac1b7065313b831bfe5f9f6df447f71ea40dc31c6faf11c"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "20feb865e7ba70d0a2de15a48b18e81b3958ceac1eb2242c08ed3726d368f23e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "96de6fba334e195de742dffe468ab4f4a53b239b64ba61e1aab63ff0b0906ed8d71acda7296d3b6bdd14464b1be989d4855a28db9ba2968618da4225a172c89a"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.jboss.xnio/xnio-nio@3.8.0.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org/xnio-all/xnio-nio"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.jboss.org/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/jboss/jboss-parent-pom/xnio-all/xnio-nio"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.jboss.xnio/xnio-nio@3.8.0.Final?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "jakarta.servlet",
+      "name" : "jakarta.servlet-api",
+      "version" : "4.0.4",
+      "description" : "Eclipse Enterprise for Java (EE4J) is an open source initiative to create standard APIs, implementations of those APIs, and technology compatibility kits for Java runtimes that enable development, deployment, and management of server-side and cloud-native applications.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "f5d1d7a29978e4ae0be5a456ee1c65c3"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "b8a1142e04838fe54194049c6e7a18dae8f9b960"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "586e27706c21258f5882f43be06904f49b02db9ac54e345d393fe4a32494d127"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "1ce4a059fda9a1c7ab751afb13ec05446d756ac418dd95f8ced369b04f6928a76cf50003f89b1b86d96bcb1df8b8f7ff31c516b5287155eea93f683f73d54ab1"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ca7e8d9c88f5ae9f193baa15da96d0c8ab48f34758503ded8058f343547c29f215f2d0db1967090ea984b643dcf0fbb6"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "3ffc3a80406027cf4baca38fca291a10d26ee50592c2a17316015e96751c6cd002991c337085b578cf897c0812ab6557"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "f475e55d86dddd85836c52580ed14efd4f6a82587b8288fce7f9599c490a41e5"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "188e5cfd93ab11a3da65ee0eb91fd0400466588dd8a9950b1a99151d60cdad564a23b35c9a723c69be889c96cf3f901d2fc91099c3daf88becda055687a183cb"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "GPL-2.0-with-classpath-exception"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/jakarta.servlet/jakarta.servlet-api@4.0.4?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://projects.eclipse.org/projects/ee4j.servlet"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://jakarta.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/servlet-api/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/servlet-dev"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/servlet-api"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/jakarta.servlet/jakarta.servlet-api@4.0.4?type=jar"
+    },
+    {
+      "group" : "org.bouncycastle",
+      "name" : "bcprov-jdk15on",
+      "version" : "1.59",
+      "description" : "The Bouncy Castle Crypto package is a Java implementation of cryptographic algorithms. This jar contains JCE provider and lightweight API for the Bouncy Castle Cryptography APIs for JDK 1.5 to JDK 1.8.",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "7c7e9a51e0c86e26e3cc39b2ed678c4f"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "2507204241ab450456bdb8e8c0a8f986e418bd99"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "1c31e44e331d25e46d293b3e8ee2d07028a67db011e74cb2443285aed1d59c85"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "6f626269d8a4569141fee47dc4db3d347bde227aa4ec23a4afdad69c3f33896a963138c8f10783f9f5b03cc7f3cd072fc7a13e6698c3d33f8c9fd322cedadb9f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ac3e72b6321c9bdea0d2f6297535af28624b2f9f8a678e135a748cfada907412e0d59a6791b0d98152e66c23a60a51ae"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "0762339fc92cac51a5d18abbf80e67c170b503cf9c316363a48f6d29f33d7c7d30040d00a476b2c285b75533a7dda8ec"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "67a9ad0d21caf68fbb4688bd1a08bdab526796861e337d6c311119e1fe645871"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "c1c2993992a6fd7286b54b683cbcf5b1f36dc60f327f34c9d496d6c2fc946368fece317962e5ac96989c12aeffb350365790c007adc1924191f65992b04fbeaa"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "Bouncy Castle Licence",
+            "url" : "http://www.bouncycastle.org/licence.html"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.bouncycastle/bcprov-jdk15on@1.59?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.bouncycastle.org/java.html"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/bcgit/bc-java/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/bcgit/bc-java"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.bouncycastle/bcprov-jdk15on@1.59?type=jar"
+    },
+    {
+      "publisher" : "xerial.org",
+      "group" : "org.xerial.snappy",
+      "name" : "snappy-java",
+      "version" : "1.1.10.0",
+      "description" : "snappy-java: A fast compression/decompression library",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "b62ca773e926e369f28deb64e1c2e081"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "356b22f323f71e124d1f2556eebe2c776509ea9d"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "470d37cac72cb11b56173a4a37f6a6586900dbe5e2b2ed182b9c7a919887d6cf"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "b2b83ab1ad496666561666f378fcddd6afc59f68b13e4903ef0aea12f9f547c4ad47bc622c1d0303c836783327b88e51bc81e1173e14de76081ea4407da43a44"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "602acd72fba731744f0d918a3fadcea57d8926a28765e97b1065624ad7eee8a70fcbce348a55bd1ae80ad63eddd3b1b2"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "ea58b3d54acd835002bbd4530dc41612e75c140266853ebad7010afa3d9a7290c3c81841e285eac2f1618df989a4ecea"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "ad40c655c3dd2c06745de267867e31941d3ccb18b5b48f9d0e487b34ae915487"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "25ec64cc71f59ffa38003f76a58c2bd69e866eccef11ef033ab70f98c90868198e12946958ec2e01d0d2b5a37c937f66f38820c769336053aa1ecb1e3de43b89"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.xerial.snappy/snappy-java@1.1.10.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/xerial/snappy-java"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/xerial/snappy-java"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.xerial.snappy/snappy-java@1.1.10.0?type=jar"
+    },
+    {
+      "publisher" : "Oracle Corporation",
+      "group" : "io.helidon.http",
+      "name" : "helidon-http-http2",
+      "version" : "4.0.0-RC1",
+      "description" : "Java libraries for writing microservices",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "dd33450b9a09f894e43322716815cdcd"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "7630988d631b8b47e1b2bdea4b670af596ebbafd"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "7c463597e8cdfa2dc3d1e54f8ca06909de6c303e1642aa10bed783a4c0c8fde0"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "46828fdd2d356ac7ea988093e4b5971f7b1279c807ba0c348f45fd0cc7deaa02584242e38ef7f78a74d2c8f9ada65ace23efe2933447a03743856da24e253b8d"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "19057a073b72ba69758fc8cdf3fc796fd995db0c4a6fc15944b1fc12fdfb2fd62f498d96c552c92a4a1ff30a9ea2ccd7"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "ba558fa59c11ca73f65f28584104f7f1d093133a64c767a9e291fe40ad5384075cbc1499f99f198077c13176d95973b2"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a435828c06b7a98cbe700ff6f4331c1b8ff8892816aa032e93a7c36ccd2cd7b9"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "28cc8230b85163cbb93c61fef6ac781a61f9eb6eabcab6d39cce061ac9d12a28fbb8de9fea89b264e90207df0b317be1a1c475cfd2e1054f65d2ed02656a4385"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.helidon.http/helidon-http-http2@4.0.0-RC1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://helidon.io/helidon-bom/helidon-dependencies/helidon-project/helidon-http-project/helidon-http-http2"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/oracle/helidon/helidon-bom/helidon-dependencies/helidon-project/helidon-http-project/helidon-http-http2"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.helidon.http/helidon-http-http2@4.0.0-RC1?type=jar"
+    },
+    {
+      "publisher" : "Oracle Corporation",
+      "group" : "io.helidon.http",
+      "name" : "helidon-http",
+      "version" : "4.0.0-RC1",
+      "description" : "HTTP primitives for client and server",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "6eebac73a449f11c1cfa45bb9959cad1"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "653248c8251c945a7b132f6b8507f0cd59934cfe"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "fca44e2ccfbb4d9f51168c8b1d397351a0aaf28327f6d7ccc124647e8633af98"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "3bd126afa77352b6ccdad4da6bb0e212407465b7eb4ca7640612ab59a986171ebf3c1a3f13f4e0fd56c3501e926229fe5d8f02b992196e7344e01fb8f8ef3e84"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ac8e197f93a1f1b974f34235d2940137dd61399e20c1661b7f3ff458881850b5e47f2ec50d4e7fb35bd780b3f8cdc977"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "9636ac5b67c418bdc5034a0cdb55ac38cc08399e433ebbec0ce2899382fa63a40a45e5566ddc9d7b4d970af5ac590636"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "5188fa06bdd125e4aad77d2fc742576a99978ae7deb4a1bccc4c61eb9a3ec2f5"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "fc6993468c954219b7733d72a4c65f1a25dd4aa3bd3094f16305fbe1522c34e03d71c00640c3495b31e6983504a697bb279e05ba564e6b4dad2beb7a2162da79"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.helidon.http/helidon-http@4.0.0-RC1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://helidon.io/helidon-bom/helidon-dependencies/helidon-project/helidon-http-project/helidon-http"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/oracle/helidon/helidon-bom/helidon-dependencies/helidon-project/helidon-http-project/helidon-http"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.helidon.http/helidon-http@4.0.0-RC1?type=jar"
+    },
+    {
+      "publisher" : "Oracle Corporation",
+      "group" : "io.helidon.common",
+      "name" : "helidon-common",
+      "version" : "4.0.0-RC1",
+      "description" : "Java libraries for writing microservices",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "15434e359cb6b8ed304c73c24b735c04"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "42fe853d4faa4030c2474bdf6298a505aced89da"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "2f4c3d0336bb02517ad7b5c1f04ecd346a1b7e8d03a3e79246cac4c96fbc47a4"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "2e06d51e8385b542fb2d38d107865e240327b3bc0aa45ae07ad1f56e876325c6417c34d2c17051c5b4d33f912d07ffe1271341612f46d8153c86ffa12b866b17"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "986c6f9cbc0a0b123e73638d28328fc59c375f214148516e9011c7f6e64705c9676a68a41e6eb3362ea9ad21510be09b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "51ce3374fdd0065919f39d499502a71a0b365aac33f6dc05bbc9e1514482184418b74aee57749d5e2f2178842a8cb294"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "950cef84b53fc730dfaeacbf47cfef8bb72ed66cb23e90d8bdd6330efe8e5dbc"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "d5e677c3ec64d5a0ffdd164101c0f4885de2e3f649330f89856883929e86fd4a48ca2add8b5fbd70aa71e5e54ce67d637c96d31e55936e94b7163bb19b504bd1"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.helidon.common/helidon-common@4.0.0-RC1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://helidon.io/helidon-bom/helidon-dependencies/helidon-project/helidon-common-project/helidon-common"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/oracle/helidon/helidon-bom/helidon-dependencies/helidon-project/helidon-common-project/helidon-common"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.helidon.common/helidon-common@4.0.0-RC1?type=jar"
+    },
+    {
+      "publisher" : "Oracle Corporation",
+      "group" : "io.helidon.common",
+      "name" : "helidon-common-configurable",
+      "version" : "4.0.0-RC1",
+      "description" : "Java libraries for writing microservices",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "d14a59ac19e377d1c93084df64a6d823"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "7777b090209b14a02a56a0f7c9ae78ecb167577a"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "24169b9f704817d73b56cb6bf7cda4d60d61e234c90243d9f4e34d7de999f9fa"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "2a9bd6df324a00568864540852b332adcdb942770c4ac4df4e292270aba7cc73fe81ffe362479977f792e06c53d8d75c803d165df10a071b9f5c9537f482a7d4"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "54337a393a1f8a99c3bd729809918e18f58bfd4a3448ea663e939e67eef008eafdd3977306880d91b3a15aba60286226"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "e88bb621d823b6c2eb8059edf84ed41049697481320e184ae361463915cda806bf124e68e6166ced7ba1be56c8594784"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "fbbfe2be63638be57daaa00ebe29a808c3ce184ff47667faff0c114321966213"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "7ac931cce3d331d5da2aa48018d435efe8eb063ab4a7327431a839fde1ac8d68aa6f1a0e9721ab5d9df6ce6dbee01af22cf4f374b62f5000f72a09478ffb19e7"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.helidon.common/helidon-common-configurable@4.0.0-RC1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://helidon.io/helidon-bom/helidon-dependencies/helidon-project/helidon-common-project/helidon-common-configurable"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/oracle/helidon/helidon-bom/helidon-dependencies/helidon-project/helidon-common-project/helidon-common-configurable"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.helidon.common/helidon-common-configurable@4.0.0-RC1?type=jar"
+    },
+    {
+      "publisher" : "Oracle Corporation",
+      "group" : "io.helidon.common",
+      "name" : "helidon-common-context",
+      "version" : "4.0.0-RC1",
+      "description" : "Java libraries for writing microservices",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "868e41df2140648b67757f3c3ce2ec79"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "59ed511e60e8279a02e13dadd9d0ac260f4f2f44"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "59e67a8660fe0ca5d0368031793cc0973aadde54abea95d0c5fdd94d599dd40e"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "52eb43f549811088f77377a98dfb011abcf0d663342a5b5401f50a936687eb88a14178f711718ca9e1d02e50caf88d51b671dca7ab459ff3e8fecc283a1c26ce"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "d51a3373bc8dd957e34aa9ac374739c5b67ead5f557f2ff9aac0ce2594c865837fb09566ebb56390839a6340ed1f04a5"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "329065246e8264c88063db98c6ddd1e0d8e3c04b1f44b4785a0ab919390ba377b4dcb5e5b7792e756f271b2e460f3c9c"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "df5e340b9e4d30c800c4573ad50949aa912e850f874534f84fa0f0728817b64d"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "bae498e95275cf3844bac5bd34e9532ebd39ec7a1958dbbeda1e2ec09d88f491f0270c29fc9bf24320c429e640dd1dff3ec02c9d969e4baed54cd30c6a46e6ff"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.helidon.common/helidon-common-context@4.0.0-RC1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://helidon.io/helidon-bom/helidon-dependencies/helidon-project/helidon-common-project/helidon-common-context"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/oracle/helidon/helidon-bom/helidon-dependencies/helidon-project/helidon-common-project/helidon-common-context"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.helidon.common/helidon-common-context@4.0.0-RC1?type=jar"
+    },
+    {
+      "publisher" : "Oracle Corporation",
+      "group" : "io.helidon.common",
+      "name" : "helidon-common-buffers",
+      "version" : "4.0.0-RC1",
+      "description" : "Java libraries for writing microservices",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "5b777ddb51b31d17f872be31b42f1c27"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "01b198e5751b56a733976b25eaa21a3b665c52d2"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "3a730bf01147d7688ca02a4e06c1d936f8d42bd01310c2a8cfca00e566e973ae"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "c102a60ddc1d941fe81b2cc3d603421fcc92c1d99f0fb8d0f654a4900fadec0481fa31a42767adcbee1bdd7ea43d73ac3388492fd4508f8e8bc14c6ed179144c"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "48158b61120975fa5af32a77291ec5c568064e3b7fc27a8aca727e49c83f9f07ed0bfbc1c5f3908a05cc305ef9469a2d"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "48dea303c1359c4dc0f77e1da08724b60f85f7911ec385efa7394eb74e10a08a307e364e7f383a0268f3aa2bb00a728b"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "84ce5b0d9058e2462b41486ee59a9c3b5aff7e2e8d285fbf147206f92d08c822"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "08766261d243817729e51ddf2874467fca2abfa07383a04094a42d9b98a3905bef6a583d1e949c8d2746d977e5b898aa019278a474a487affc71ff3e3776686d"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.helidon.common/helidon-common-buffers@4.0.0-RC1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://helidon.io/helidon-bom/helidon-dependencies/helidon-project/helidon-common-project/helidon-common-buffers"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/oracle/helidon/helidon-bom/helidon-dependencies/helidon-project/helidon-common-project/helidon-common-buffers"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.helidon.common/helidon-common-buffers@4.0.0-RC1?type=jar"
+    },
+    {
+      "publisher" : "Oracle Corporation",
+      "group" : "io.helidon.common",
+      "name" : "helidon-common-mapper",
+      "version" : "4.0.0-RC1",
+      "description" : "A generic mapper to convert types.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "d231a81c584fed519891bd061129ccca"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "034758c856104c3c71626691e4e3437d07f5f816"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a254b4767219f51ff4b4866494b08b6eaddac1f1b125dd102441df55771e4900"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "14ce199d684995cbc8df79ec4a5b61c876bb621f5799341321371b4b9d816159508ad20a2ee229bf7afe231995634a3949af429bf647dce5792336ee3370b7b0"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "40200b39690142e95825beaa3331465e4cd07ef0e6c88e90eef70cc55257f900d0177800cc906e0c742204fff6cac72d"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "c59423355f2bb1a2ae42146fe6bed6d7a06f221a7845711e6656f622501d4c3b7984bffc419333b3e7afa6d1a0b5469c"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a2f23e90c1735aadc183fc229e565d1acbe592806c16a36a946e12d6c169a811"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b76f0ea487354c2ae13bab9df87052f69880d9240d8caec2701ec9bf21e549981db4d16e5e9774fb9d154805272c53adcd7bbdea4f0216bdeef16cdd58a4e6bd"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.helidon.common/helidon-common-mapper@4.0.0-RC1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://helidon.io/helidon-bom/helidon-dependencies/helidon-project/helidon-common-project/helidon-common-mapper"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/oracle/helidon/helidon-bom/helidon-dependencies/helidon-project/helidon-common-project/helidon-common-mapper"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.helidon.common/helidon-common-mapper@4.0.0-RC1?type=jar"
+    },
+    {
+      "publisher" : "Oracle Corporation",
+      "group" : "io.helidon.common",
+      "name" : "helidon-common-media-type",
+      "version" : "4.0.0-RC1",
+      "description" : "Media type support (usable both for files and for HTTP)",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "903e87d5f5a75082c96a3678f226f2df"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "e4789c9f0ebe139e0d0533343369a343e13489c5"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "e2c6b5db253d56e665f76480f5baf823c9d5c9fce92ac51e13111a1cc9854713"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "55b431568e45e110f58a9648080e317c0c8e15c86d4642b423f58f8bdfb5af9a6353378315eadbe8f43dddf06078ad6c2d12ddb8afa6c0ec214c33bcdeca4231"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ca0a41add9c0e77b02152764c1b825d971d54ae911cb11239dee39b5ea0fe161e7429ccf21c16cd95146c6be494bb053"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "f0aacb51562006aebb854f677b47f78b6b5349de9e6869c9cfb2ad0148c437de8c2e241672388bb370960e4b46f0b896"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "aa762493c317e6bdc8324da21d343cfa89f1d4eec6d2d22bb9cfea9c33189a18"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "550e7556097132e67d445ec5ed0088b8f3991b95bf23f0737b355b34c1ee0977469bb27382c34dfde9d119b9291ee11a2e896e89d88a521a92ee6c678d55d8cc"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.helidon.common/helidon-common-media-type@4.0.0-RC1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://helidon.io/helidon-bom/helidon-dependencies/helidon-project/helidon-common-project/helidon-common-media-type"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/oracle/helidon/helidon-bom/helidon-dependencies/helidon-project/helidon-common-project/helidon-common-media-type"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.helidon.common/helidon-common-media-type@4.0.0-RC1?type=jar"
+    },
+    {
+      "publisher" : "Oracle Corporation",
+      "group" : "io.helidon.common",
+      "name" : "helidon-common-uri",
+      "version" : "4.0.0-RC1",
+      "description" : "Java libraries for writing microservices",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "a67316529081eebe084d3e1a8aca3029"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "ab0127d4fa60f38b70106cf01f239f435dbecd36"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "672f2e56a1e5507bca5d0e554679cc448aa02bc73435cd9ad34bd6d42aa69bc6"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "04626a0216e5d3cd87f77c5f69590d714eb3cb72cf9379155c7599e4e786410bb91a6d80b749ebbdc8ca08398825975a54f077640936a2df2323d1c629857fb1"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "0f378d29de265da86efe6db204875d472b0ef0c4d3ca482fa5b5daf380a53fcd9d556922cc577c599b801a01b5fbd3df"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "e1fc5e0717d2ebce3fe064f512a6da117297095d0d3cd229a4ffcbebda61440216c217cb1466234c2af8cecac05479c9"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "cb02b2a7ac68fdcaffb02a626954533f277cb6e523a4b6f244f4413a3a303409"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "ed5dd56aa29f1b1af8ec5d541298655c9e743e86b47f27e1096a5017b620d8e7c46ff453a86ac71ee8df53666f6dcb0ea567a6e93f1cb6043517c857ec070243"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.helidon.common/helidon-common-uri@4.0.0-RC1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://helidon.io/helidon-bom/helidon-dependencies/helidon-project/helidon-common-project/helidon-common-uri"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/oracle/helidon/helidon-bom/helidon-dependencies/helidon-project/helidon-common-project/helidon-common-uri"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.helidon.common/helidon-common-uri@4.0.0-RC1?type=jar"
+    },
+    {
+      "publisher" : "Oracle Corporation",
+      "group" : "io.helidon.common",
+      "name" : "helidon-common-parameters",
+      "version" : "4.0.0-RC1",
+      "description" : "Java libraries for writing microservices",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "d5ea50a2c75f476f1b1b342cd47ed129"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "8181616231354f5d0a7e732ee2a441e7968c0580"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "61e999fbb4c78e01bba2cca60a809de3795091d0a48a46ecf15482fcb6bf45e5"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "700c963864b09d49cebde99dc429efb0330328a18b36b209d1eace6a73d9268a3726ac143e7726626c41321296570b1ba4186a208f84859d81f5c9a261b19419"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "e60cae58ec11c92f07d608c8a33253846f887f9fec2dff528598abd90b094bc3cddd1457d763104d04177b0af4ee8989"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "ddc4f8b2e087c34d1ebc4c9c6a49bb1a33d616d39f19650ddbec53c6b8aefd382749062137dfc00f3b38a05d2b56c2c5"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "4b6e34e4ff6226bbefd0150941539cfcc7a5b2d4e9450c2d01e559253a04dda6"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "a31f8f63c75ad052ce0943f82f6b929e8689aa786513b76125a23c2e31934184c2d5e18193c62b719b9f86ac32a1e8005182a33934f9c05e6bc433b350a5193a"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.helidon.common/helidon-common-parameters@4.0.0-RC1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://helidon.io/helidon-bom/helidon-dependencies/helidon-project/helidon-common-project/helidon-common-parameters"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/oracle/helidon/helidon-bom/helidon-dependencies/helidon-project/helidon-common-project/helidon-common-parameters"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.helidon.common/helidon-common-parameters@4.0.0-RC1?type=jar"
+    },
+    {
+      "publisher" : "Oracle Corporation",
+      "group" : "io.helidon.common",
+      "name" : "helidon-common-socket",
+      "version" : "4.0.0-RC1",
+      "description" : "Java libraries for writing microservices",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "b4c7167e16b036e8b3a980e5bd6e3fc9"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "1a7918132581e6469be22501c9542b687d0cb6b0"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "cc40b665f066a0037cb5c341f9b25f5a20732b4544092768ed21d6dcb797c704"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "15ccd9be7d4105052ec354a6a504079577f8730feea95c6747cf14cbaaa793c4b5f42326977e0a3a1e93d2934467bcd99078ff943785adddbb215f0df3d85d29"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "cbe59f7f584726109fffccd4127408b540d80eecc7ddd93adc204c9fd15a7a735210dcd3268033b2382763266856bf20"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "de80ae71e9dedcde82a3eb867e376db2e0bfa86b0fec069fbf475bddb69980950b8eb2f21b39d987772eb9621dfeca3d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "af94c0e4326302f2648f692013260bf228fcce583182d5fdcb9b24850913a25a"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "061e10f0fb15ab29b0e9732f8440f8d46c138cedf2c9af0ef421610e71e82ac73fd8685b82886cef388c26ccb844c9f11e7eb33c697c8b6571b71ee76d6306c6"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.helidon.common/helidon-common-socket@4.0.0-RC1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://helidon.io/helidon-bom/helidon-dependencies/helidon-project/helidon-common-project/helidon-common-socket"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/oracle/helidon/helidon-bom/helidon-dependencies/helidon-project/helidon-common-project/helidon-common-socket"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.helidon.common/helidon-common-socket@4.0.0-RC1?type=jar"
+    },
+    {
+      "publisher" : "Oracle Corporation",
+      "group" : "io.helidon.common",
+      "name" : "helidon-common-config",
+      "version" : "4.0.0-RC1",
+      "description" : "Java libraries for writing microservices",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "df0723ed40c03343d120df5a808e4657"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "60e08c196afb9dc357cffb8042eeae5b7bc184a0"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "ac0ef619d266922d422d3106443861a3cf8245a428bad87ad6f170643eaaa15f"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "7fa91ac8555626c2bcab5078bb392e19bb42f2488e6fcd10a4a2e259bccfba0b8c294167f937bf7f0a7f987c2e44e7d7403f556bc463fe02bac2edbc6015b14b"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "042123f9253d85f029b2cf99f87101124bf2d16ad93a772ff63265dca7ffb19d962430d9b2ef29129e2a86e31285bf1b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "25d1cfe5d9ac42c8df6fb2b8b04924f6cbf7f507798d309d14f6fdcb12b67386db9b506047290006b37176616b49f16a"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "fb0856b59f0a62d5412580c845e9794e1d1f6d7adc0412977ef407a87c44d53e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "c412b3cd15cb8870ede5a8e008fe6f1efe37437791b81d3347b783b9f279b9b5b195941b372fe13a234874c7ddbb2bf264a300bb204c99f8ccdca01febfa7f08"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.helidon.common/helidon-common-config@4.0.0-RC1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://helidon.io/helidon-bom/helidon-dependencies/helidon-project/helidon-common-project/helidon-common-config"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/oracle/helidon/helidon-bom/helidon-dependencies/helidon-project/helidon-common-project/helidon-common-config"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.helidon.common/helidon-common-config@4.0.0-RC1?type=jar"
+    },
+    {
+      "publisher" : "Oracle Corporation",
+      "group" : "io.helidon.builder",
+      "name" : "helidon-builder-api",
+      "version" : "4.0.0-RC1",
+      "description" : "Java libraries for writing microservices",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "373148ccee2a79efc60d6730554371a9"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "290538c640ca1ffa630c5895a99dfc03d8e05f73"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "33287bf193575d73064d41c57a9a509d41367f8eaa4949614539f83dce86602c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "d0bba1426b47dee2e32174cf87f7e6c2cb9b1bf462a78fa21827a8b36efaee264df537b569624a0f2a6e4fd87528295ceaf28f8beccfa9c58c590f896c81dc1b"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "938b012cdedbc649f4917c4ddc121f79988c7609b4397e937058d82f3e2014778ce92d2837808f774c9d88309b07e8d6"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "3d1b8f8abd65a17adb3666b562f22e955315be3b456d59338b78e2cd9c78ec79e98f972d85f567646334986350a4d99e"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "f51bbba05164f98561e780bf87e15be688ffc48fcb32df5e4606b9248ee1f5b4"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "41b782e6dfb31127658c7095bd031d339d2c2c885a4fa54277b65182ff3dc9b9d70d608aca492fdc2def6cbdee21fea8ab49ed3db98fd4d653323015eb7d0d20"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.helidon.builder/helidon-builder-api@4.0.0-RC1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://helidon.io/helidon-bom/helidon-dependencies/helidon-project/helidon-builder-project/helidon-builder-api"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/oracle/helidon/helidon-bom/helidon-dependencies/helidon-project/helidon-builder-project/helidon-builder-api"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.helidon.builder/helidon-builder-api@4.0.0-RC1?type=jar"
+    },
+    {
+      "publisher" : "The Netty Project",
+      "group" : "io.netty",
+      "name" : "netty-codec-http2",
+      "version" : "4.1.99.Final",
+      "description" : "Netty is an asynchronous event-driven network application framework for rapid development of maintainable high performance protocol servers and clients.",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "6b3d5990d720214e20a46f60579587ef"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "c5a3481c4bb9732a3a94fb63cf916141a1a14669"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a66eb05f321c6f859a10a018ff210754df390b1b83a4a09d5ca603f2e2e7228a"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "13228e81cf3807355e733d7edbd93e149af915efa164ae03ce17f0694ee3062450b580f210098d44317aff3bb15bb56bec661d2696f6bbe6f70bbff19222eae3"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "770034e8cef3c8b156a3822dd67ab092542b788e448589adb40201b95506d436724bea85d9b016ce297a6c833ed1ac6d"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "9c98f103790c83caefd0b2e7a28c966812253572c9ae3d86d760ed73b03b35e7e80cabb4c4a2ce627246bdd53dd3c970"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "03cb46d40b3f50cd6cabe2646218201969c7cca826ef0d3098928741b7d7c15e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "1c2c439212ad531895ed1a14c77f5bae12361933447d97df134d6221416fff03b7a98412d9f7e18c4369869bc770ed12f9d1a9caef883225971cbffe75c9fb95"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.netty/netty-codec-http2@4.1.99.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://netty.io/netty-codec-http2/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/netty/netty/netty-codec-http2"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.netty/netty-codec-http2@4.1.99.Final?type=jar"
+    },
+    {
+      "publisher" : "The Netty Project",
+      "group" : "io.netty",
+      "name" : "netty-common",
+      "version" : "4.1.53.Final",
+      "description" : "Netty is an asynchronous event-driven network application framework for rapid development of maintainable high performance protocol servers and clients.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e1b6bcac88d1e48a68bcc2dc6e63f951"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "f5aac2cd268483ded1f76dacc5c9eb27899dee72"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "0fc9d8ac53dcafa7823498cf668839d3fa164ea2e02eee5946c5f5061f61a5d9"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "55ab83a6cf3f46781bbc03ce62caaed0894ff433c3db9f56d69dccad8da82652f5fabdee3d8836dcee63847980bd24062daf50d5d34b41894428ab663de7d863"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "8a7558b784ba1be1481eebbdc69ffc3edf70328460ac2c166a106b4d8643c2b8dc880e6ec8ef9d9cf306a5ce849be83b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "aa1020826006cef69554a363a533d1b4ec3a1b524fa787b645f6f980fb6a303d8881f07cb2ab6601b47ae70c753addac"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "630088536f5b01609cd15b6f6ad39de93641b2243ecc5671632dfb13a0d8c1e2"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "ed39cdabf297606fe9c151df78fbc611b37ef7aa5314d3c2ac358c45b1494d4a0c9715c7b731ce1160e5bc4fb7111dcbcb974f0c40dd6a12edfeb24bee824670"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.netty/netty-common@4.1.53.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://netty.io/netty-common/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/netty/netty/netty-common"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.netty/netty-common@4.1.53.Final?type=jar"
+    },
+    {
+      "publisher" : "The Netty Project",
+      "group" : "io.netty",
+      "name" : "netty-buffer",
+      "version" : "4.1.53.Final",
+      "description" : "Netty is an asynchronous event-driven network application framework for rapid development of maintainable high performance protocol servers and clients.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "fc993dd8e54e2e5b4a9004026e4dbfa9"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a28d2694ff1bc95c627108b01949de3697b4c232"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "63b1346bf9c97ac3c78db84ce4ffe32a69782724d337db7849cefe4e53330f21"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "c2bd1d97057ab7825d3fa497991b9a8b58d0ad185708d4d2bef32dcbaf7bdc93ffacc05b727fb392728fd872dd4cf59d427b2e5cba953d04badd3e54c9e211df"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "43505b010bc27fa02aeec984d377aac73a7185b4b861497b1e3ce9df40073b1a980f7e8331c8af1a440bffa7e2960d15"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "85bf4d1de5b5d64d960016b75c592ded7d200150bb466b9f1a186328fc47b0d0ef8f85a67e06c4bac0cb05a7626bb850"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "6068725b877d54bd8da37a3ea7a3958c8530179c1b628c45b3de7c9f96b74a9d"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "3e89908e5ae21b6bfed33971e9b191492daec5a4768d404d3fc83650029fc3280e8496c2d10984c08331274cf4ca7c58945d3c7d757697cb1b61834e9e12cd6e"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.netty/netty-buffer@4.1.53.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://netty.io/netty-buffer/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/netty/netty/netty-buffer"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.netty/netty-buffer@4.1.53.Final?type=jar"
+    },
+    {
+      "publisher" : "The Netty Project",
+      "group" : "io.netty",
+      "name" : "netty-transport",
+      "version" : "4.1.53.Final",
+      "description" : "Netty is an asynchronous event-driven network application framework for rapid development of maintainable high performance protocol servers and clients.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "3ce6810f02bc82c99af1630430cb9e69"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "0856f737f7c512f2e2b970df254f15fc558e991c"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "140ff7266eb56762b7bbb9220e82ee27ad1f2f1dc262abcec6d7137cfec5bd00"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "d39a3fc963bdfb8ee5bcf73cca3ae489643c9d7c82b68250953c33dae046754a4a893c8cf2b863a43dd805f82d340204d291a2323710a5d2c51fb6943f6573cc"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "6d8c24e760cd633dfdefe6a1fca2695fc1481ae04760d4fc382a4ce7884b64daa1cd7d02dab9742a670a9c7aff9be928"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "c4171aa59fc0a74f6b98703bf57e92e09b937ebc4d4f1ef6a0c4a1b823f5a30210d44b72a2b158f62fc52ff1d666ca91"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "d123c7e89b6c9ac44b5fd3c280a5dc83a55a8755729460037344f57c8b33fcb9"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "310f6a10e5a8b10e44d0c470d7919da21c575f296cd8db451bc648a2d35c8f0ef0a21984b0c6893e9e181dc969279d42ab818c655be21b681066d632237aaaca"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.netty/netty-transport@4.1.53.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://netty.io/netty-transport/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/netty/netty/netty-transport"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.netty/netty-transport@4.1.53.Final?type=jar"
+    },
+    {
+      "publisher" : "The Netty Project",
+      "group" : "io.netty",
+      "name" : "netty-codec",
+      "version" : "4.1.53.Final",
+      "description" : "Netty is an asynchronous event-driven network application framework for rapid development of maintainable high performance protocol servers and clients.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "1d45bbc34ab6dcdec91e25c9ca1aaf75"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "47aca7eb6f3a4ea623195906dd9caf3a1863e187"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "de3239f3a8d5bdbc8c5049e00d0ab5415d1ccede30cb4e322694e8ffe3e354b5"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "99b84fa20547d1de41ae780538579f2e5bfa91f43a233a0892de7fdf2338b52b053ddabdac21d5ddf1cd2648312e80b3cea59941d59da38e986b93b797cd1e10"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "91ebd53bf78f3e1073d45857481a30e4f0b3991924006dbe475236566bfe3e26a647ac5fe9d273972a621707e76c9b73"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "c4424f4ced08cc2e6cd231e6e079c35736c84ef079cbdd9a06c2b7937792fa3dc5e89ff2ab04503ee2205f09f0a803e8"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "d6c2471e541ac78f4c96295dac8703b912bb8c09a8ed404bf43e4997e0ccb3ec"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "40c140333481af5898c76b245e07fef542ef7327d3455713c3cfa39534d3e34e62ced3e42e149bb3e8eee5d68d887456ea9ed094b486d0de7ade4ed4cd7a8161"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.netty/netty-codec@4.1.53.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://netty.io/netty-codec/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/netty/netty/netty-codec"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.netty/netty-codec@4.1.53.Final?type=jar"
+    },
+    {
+      "publisher" : "The Netty Project",
+      "group" : "io.netty",
+      "name" : "netty-handler",
+      "version" : "4.1.53.Final",
+      "description" : "Netty is an asynchronous event-driven network application framework for rapid development of maintainable high performance protocol servers and clients.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "13813585008796b2030f7dd29476b81e"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "106846090e4bab23537d52da281616a001611e0c"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "6b5bc48c787af3d14be2387d2b180bc0f50e7dce7a7eb3afa7e3dd00c68f37e3"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "aea441bcd1a62a62db8c2c8c41440b4dd42ee0e3130b48251d35c15cae7e95f66798643aa41083cf123443bb2cd2f6546c982ff2c97e08aa8133cd2946b9a947"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "2d0be2f2f5e0104de380e8125d262a49a36db38ff70742207506b93aebdd782fc0f4048a5eba171f9f7bd87917963f94"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "cfe4b3fe85f9fda204b591519a5f8cfff0a13cf038851bfcd15b103db247c2b313ba74ec385636f30197189b68a2ce4a"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "d0cd929b3cc240f4db418522896e2303d9afefb93d5a1e344dc91418cde89d0f"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "dd5d46a8a8863aadc0a55893a7d04532eaf77e3096caf1668c289407e14cbe25244c9ba76beabbfc21cf9a2b6f16ee7fc1dcf2868c72e3dd641974c2adcd06cf"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.netty/netty-handler@4.1.53.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://netty.io/netty-handler/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/netty/netty/netty-handler"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.netty/netty-handler@4.1.53.Final?type=jar"
+    },
+    {
+      "publisher" : "The Netty Project",
+      "group" : "io.netty",
+      "name" : "netty-codec-http",
+      "version" : "4.1.53.Final",
+      "description" : "Netty is an asynchronous event-driven network application framework for rapid development of maintainable high performance protocol servers and clients.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "20b03d7f4c78e530aa768d41d67d831b"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "9f62cacb250ec65bdb368a178d2453535c365947"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "48a81eec058871c4eaf66670f824a76f403579c53ac7a6840dd6ace9dfc4ad4e"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "d5095daac93d0705c8cb59a35376c191e28cfafa4c466c95d8417ff60d363b489425870cda5c0b71089b385f6d1fdee7d7bfdafcf58615b954ac2b6cdcbfadbe"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "3801bd0c1f27db284f08d694518c9535c5afb5df2f908f3f193590988b68038ccb337ab1b59212105875da849b23f26d"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "1aa05da2d50fa7d7e27f8814e668f62e4c344f79aea77a0ff370decb653ac9db046813721c918fb994d3a77f31d58497"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "51462baab29b57a9c07fdf804800de091a1479f9e799354e1a49da5a90918f19"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "23b4052174187e5befac72c37171a724cbe71813483c56cf21740326baab0f9bf2003a3feff928da088dadbf6c924386cbb5471f6b00a1e9b680e7c5f3322481"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.netty/netty-codec-http@4.1.53.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://netty.io/netty-codec-http/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/netty/netty/netty-codec-http"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.netty/netty-codec-http@4.1.53.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-keycloak-authorization",
+      "version" : "2.13.7.Final",
+      "description" : "Policy enforcer using Keycloak-managed permissions to control access to protected resources",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "89d17954621e269908f5a79ecfea2f94"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "1043a1355add7c13a5f694672e1759ca044472d6"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "1d01f9d25e1d4db3340bb6395d0f20b40a57b4cf0fef756f030294daf588a75a"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "190c457c79e591bef0183dd0f24cd7faf79e819b44b8a7d3d0a480a473b7b5d32a862e22113a800e6d1506e1b8745cde9d01af9edf55cd42843797e174c3ecba"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "7fe18548812ae300f491b61b6714038a5c32af3ef64368e21e50bd1c060cd71f85fa061c0f76e6fddc0268dff90e1005"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "b774d8778f66432b7f12d4b4f87593c1492605f0e3e7858859ead01fd2b525c0dcd9b3364d7533ca757caee5d73ffd67"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "4555360177950fce879d1b76c2a7d0b35eb51d92a7863c05717c0a12245414b6"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "249d0d4c6a13268a29d7eaf898b569be1dd299b802f1e9d3e258c93122cd412b623a33a7ee92d86054c9360d73cdd77b7cbea91327e02b8e0fe565f84d2e7207"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-keycloak-authorization@2.13.7.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-keycloak-authorization@2.13.7.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "org.keycloak",
+      "name" : "keycloak-adapter-core",
+      "version" : "19.0.1",
+      "description" : "",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "989da0683fcf7db6c7a43b6dd8f80f73"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "01012ae44e1a7f7214db018decd6033c568c5042"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "8c18849bd218dfee0f1ffce83aae379776fc0beecf29cee08f33b69f81b64964"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "37c097253e6f1251bf304910989cc7404294ae7e7fe50f4d96a9f4167fa55dd8a831baee273ff34b67b6430f4f07e904d2fd9c7084bed98a26db8e2e242acd84"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "4776306534c1e9e27c89173f938c3dcb4b6723dd925c6146065063451b6b7dfecf1014a4931e3df2125238307e0c05a7"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "9e7051ed57c659881488ef17d1c665c24bc558cb81c4d28949c0f21242e542bbe2a45c754fb216ca2d8b0420e7e36f6a"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "f44d7f21f9ddf2d6108501300a37b7919babffd7d82155cc342548e2229425ca"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "57052cc514acba95b0b460acc859d215c8fac9adc934a9f2b93e2ee1e8b375b9c513767ae341556e725e51b4a1643ba9328ef97380dd8396a158e011ca6208a4"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.keycloak/keycloak-adapter-core@19.0.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://keycloak.org/keycloak-adapter-core"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/keycloak/keycloak/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/keycloak/keycloak/tree/master/keycloak-adapter-core/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.keycloak/keycloak-adapter-core@19.0.1?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "org.keycloak",
+      "name" : "keycloak-crypto-default",
+      "version" : "19.0.1",
+      "description" : "",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "dc2c70e0306301e6bbd821fdc41b01f8"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "d5ccd221302ee25df7da61567c1af2d34d9ea346"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "e426869d179dc4075c641e6d3840a354ed3b7851f08546e8839450f7d976c4a5"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "45867d18bf041d4aa760ed0c753596a0831af654de18476b51a94c4de19262076203544ea0fc859d771ba08053570889dcfcfff4be6e81039b23d482abb73bc0"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "b78f26b883c8e90d67c2c42c09e1e3b36f6504c0ecd013a69e73066c2253836e519f4ed89ce0db506f3ec3a2a0d60ad4"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "04a82e7fa1c2ab6a545bb197fc466586b8bbf111b070fa23dafd6237a846336de125013b52f8857713b664b2dcb9ca9a"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "070245f8649c4c36f10fbeb9491b42a9026c97d4a1230c37de7aa57f33b4a14d"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "be890744298ff79fbca0fcb6ef49cd70475cea2752699bd1099cc66786531a9117df3efde33392a1dbe581eafdd0e3c7f3b22847aa03a02936c394f2a27905db"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.keycloak/keycloak-crypto-default@19.0.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://keycloak.org/keycloak-crypto-parent/keycloak-crypto-default"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/keycloak/keycloak/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/keycloak/keycloak/tree/master/keycloak-crypto-parent/keycloak-crypto-default/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.keycloak/keycloak-crypto-default@19.0.1?type=jar"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "com.sun.activation",
+      "name" : "jakarta.activation",
+      "version" : "1.2.2",
+      "description" : "Jakarta Activation",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "0b8bee3bf29b9a015f8b992035581a7c"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "74548703f9851017ce2f556066659438019e7eb5"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "02156773e4ae9d048d14a56ad35d644bee9f1052a791d072df3ded3c656e6e1a"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "8bd94a4370b827e3904f31253b022e5c1851896d3b616ca7daebfef259238cedc56d4ced32c74f24a13c3e2295b0ea012af5d04656b7f713cc53a2f18d5e2cf7"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "1cb0aff8b73ba52a9931b2cf13c75a1ce6665fb826bf97ede66db75c532136aa189fb53a1925e62b6eef572309ef3b9a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "83801332576d931f4091ba65ea240d49c23e3b93dae939ce2eed63de943f80f251a4347638b99900de5b831796b12590"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "5363211b59dfaff6e1973e93548e5e4062189c6d0f43d7802627ebeb7b7ff37d"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "0c7b62a3432b19ffad02eafffc7e598391cd32b1313d075f94cda09913402770b4ba2314716625571f266431067229c93cec36e17c3ea598623542988634ca0a"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.sun.activation/jakarta.activation@1.2.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/eclipse-ee4j/jaf/jakarta.activation"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://jakarta.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/jaf/issues/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jakarta.ee-community/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/jaf/jakarta.activation"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.sun.activation/jakarta.activation@1.2.2?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "org.keycloak",
+      "name" : "keycloak-adapter-spi",
+      "version" : "19.0.1",
+      "description" : "",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "f0f0798322acb51f15c69d2d520ae230"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "f0de9bce0c9f54c482d9735323e747947fcd8e2f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "8d5e73a7432d6677f1bf2354d1644be8a362a2be4bf512d1ab5838fcb9497df0"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "7b0d83eac9942b74e8c6f033ca759949ab9d1cd59a6c22f31cba85996b732825e269b23d9f347c4667de9131e451e9164b566dbf0e8356598936c126fa351a01"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "f2b45afea8d7cc98792653d2d9a4812132a81b3ee7edc6dc3fcb005118495c81fa25ee6671f2169be40d7c4b8b1f114f"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "4fb4fc8ebcbb365c54de3c995812c0a982798ba025ff829a45849800c947591272ee4218e466c4d3b6ff2127f612ccd3"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "4ebdfbf6f9f458a47cff8e7d3f83d5091a562a2fcea16561f86c6d2b736ff39c"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "f29db059ab8f5c3ade6c09c2e080336ead19a0c000fd729e335aff33cbe9b9a3e2453bdd49873b65c2df3b9165cebb4fd32ada2e460d9bfdaa6a3bbf01b43aa3"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.keycloak/keycloak-adapter-spi@19.0.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://keycloak.org/keycloak-adapter-spi"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/keycloak/keycloak/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/keycloak/keycloak/tree/master/keycloak-adapter-spi/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.keycloak/keycloak-adapter-spi@19.0.1?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "org.keycloak",
+      "name" : "keycloak-authz-client",
+      "version" : "19.0.1",
+      "description" : "KeyCloak AuthZ: Client API",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "8ca671bd1cbb006306446003f22ee943"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "f53a85c616dcb86535d98ce9e257951fe626f187"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "3671a9da49f0721c19be78edeed47e18e56716c2c9d41d7ac32e9142b2d66298"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "6833ca3bf04f8158f8f18296428628209cbbab64ece271c4804e6c094c8f1aaa6fc2560da9204339210e8a426a2130f00106ce6d74343981d7519f2e4074e90d"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "6df2526f58b4a794fe20a1c6616908600e94a6813e1b87923c50270fb6949cc652b767456f432ea19839d8464d716f06"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "ae1810d9f72a0d60486c3a722b47bf77d2150f2699bad8ed098f0224d726d33a1f9cfaa32e809718ad2905f18e82db64"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "b587677beca42d875b9c9cbbf871d35f609ab908081866a81885af0bc56769fe"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "dbc4c8e58dd338ef3cc11c5095abe08db9c6de860fc22fc3f079093c3fd8a2642f5cece4bedf811cfe14e17bed35f890a251eaaf037f3dbf0789f5f1c6b3528d"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.keycloak/keycloak-authz-client@19.0.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://keycloak.org/keycloak-authz-parent/keycloak-authz-client"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/keycloak/keycloak/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/keycloak/keycloak/tree/master/keycloak-authz-parent/keycloak-authz-client/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.keycloak/keycloak-authz-client@19.0.1?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-apache-httpclient",
+      "version" : "2.13.7.Final",
+      "description" : "Connect to HTTP resources using the Apache HttpClient",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "7cd74b4e782a0f7f2b8411fa818505d3"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "ccd1ab7db6f2f6049e8bec784eb903f8be008b86"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "6449b307954b176ff22747825ec2e998fedaa05abb8c5d6a42513a65ac1b0aaf"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "ee9630122166babb14ba7ed2ec844a6a8f621d0404b3ee54bb17fd9a917f95b13d65f00011e6fb00378cc00017acb8614dd58434ae5362ee3468a56230c7590f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "3f4980f7d60a128a5388aa3c7accae8979aab66a2f24ea83a55083a957a00f36c5d1247ccd2992536a25ffb856d95d35"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "948a1c08c9b016da7cb910aec524d04c254c760cd321d2f2b577e0eaa5ec4b1c6a1e0fb41789cd0264ccbf7000132ab6"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "3653008c21cf11876798fbd9abec98969cdcd25fd23828c4b884596e071e1f3c"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "a76ddf8370aaf80b54e1531fc53b0903f9adab1163442aa18e11007393a5199ec060eb85010338582681b8b05b26461c6cf2638594c21027ea4737bfdab53942"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-apache-httpclient@2.13.7.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-apache-httpclient@2.13.7.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "org.jboss.logging",
+      "name" : "commons-logging-jboss-logging",
+      "version" : "1.0.0.Final",
+      "description" : "Apache Commons Logging to JBoss Logging implementation",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "46328c16f47be35563b73425d456445a"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "27a4e823d661bde67ec103bba2baf33cddde6e75"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "f12176263ea25f4e78bb4fa4b36d335a29738dde6a8123e1b6da89a655d150ff"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "b56221f841fc73f8547bbc1bf06c6b8a635b6009d342f6d0f321a0c5895f5c0876d099c03f98ecda9728ff523c06613ab2cbb242f3e45c7ed4d497d9fc24aa5b"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "dcadc6881b698e04d426b30831d05df8c25712fb1d0782b8307d8a2f54afddf75c7854c7cbfadcd8533a19e63214c79b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "1bcc924caf9b23e1c3dd46b0c52281765bbf7fb34609288c9c1f425a74f4c15aeb37a050eb79326491a74136e2c85d58"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "e622f1f358e48847675b0d8901c9474f7a3a1da71d110380f3543fb9b677c5ad"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "a31abb471f63a32e49f0f8b2aa94acfdb6f2a527d8ba2a58229e959067638175a9f2a0ed24e1ba052515e6572300af46adad01091eb1f36cdac5a6378c956190"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.jboss.logging/commons-logging-jboss-logging@1.0.0.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.jboss.org/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/jboss-logging/commons-logging-jboss-logging"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.jboss.logging/commons-logging-jboss-logging@1.0.0.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-csrf-reactive",
+      "version" : "2.13.7.Final",
+      "description" : "Use Reactive REST Server filters to prevent the risk of Cross-Site Request Forgery",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "0532cbd0870ee44f856e4264e87ffe41"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "5ba3e22100b0a891ed03ff96aa7dbf3c2bf976e1"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "664aeb9933e3a1633158c73296849cf6a1621854571b4faf2f0ca14e34a50374"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "c55a52b9715d0356df0149b22d48a296a47911438ed56ec2dc22833b7cf364fdb993c3671d11be4d089c8c4543007900e51c48868f8e9870d8e319ea93a73ba7"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "307c5fba039476ce7ec2aef5b8b0ac82b0d23133c8ad6401db0bb7c6c76eb72ad0a5f5571c7987400a1a91ca6e75b99b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "8e759f55f969a8e1f39281201d7453c243bfcf52d5e617fe99f684b42e930251749bce51313de6a7bc27e98ddcca4e03"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "e3b5de58cebaca447181f8a2972b45058068adfd9864210c536f987ae4d7d77f"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "bc2453be34afb1cb9aad6473c41b26a2bfe98f8587184c9ba19db3525398b40f641882a5e072e3433602d22b2e2c316aa51926f18ad87d7927d232514cd6fa46"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-csrf-reactive@2.13.7.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-csrf-reactive@2.13.7.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-resteasy-reactive",
+      "version" : "2.13.7.Final",
+      "description" : "A JAX-RS implementation utilizing build time processing and Vert.x. This extension is not compatible with the quarkus-resteasy extension, or any of the extensions that depend on it.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "6a338f9588f90c6f0a8edfa77c694448"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a869564eb549bf261af63edb2d48fbc1adb93ef9"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "f7a6161f6884fc6a2794e0ef2f30d1fad132a9f539dcbe60e50cc8f66fe0fb38"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "44a66a71fe7752121db75376fff074d9594e172611a97567f7d1ab87aacdbffa2dbf5a350f101d95f20de1b6ab08880435329e4b1b73135b092049cde46d28b6"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "c7312ab56340729039a100f90bdd287020098a05bf681c68857a0a8c7c860123eec49766e7fcc894b2beef685a0a088b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "4bf5988387e1a5bd71dd269bdda7f23034fb430333c7f60122dbf45dbb23275fb62ca728be665dfd2cf994891e00efc4"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "3a3ab2cf4b4e43fbb31a2a689e48385f5d96f6d476cf02e9ff6009a3c6be0629"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "64ac341bf5e0a8dc8b8933909ed620956d3a1a584ad920a79b862af0141b6e0aade3f422f0bd55073af021790b38578ba33b8e5046497a52eb5877bcaf07f100"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-resteasy-reactive@2.13.7.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-resteasy-reactive@2.13.7.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-resteasy-reactive-common",
+      "version" : "2.13.7.Final",
+      "description" : "Common runtime parts of Quarkus RESTEasy Reactive",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "747b7664678d2c5f2d052985d4db1526"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "809ec81b86389ff1146adbb994b6b0e0d0b0f8be"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d4ddd5abfb8485ff8bfb26fb537ef0ad1a35ac76c000274436913951da837678"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "563a381f6da9ce2c9f494e2428e55946b0569c8aaa816f8336f6edb6551c001251e911d37451bc8f485a0c5f2f8416756444dcfbb5f97ef45094977ead03f3ce"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "be1466fbf840c11aa4ff84ea604fbad5ff97111bd69f25df1f31be01ef3427432bb04bec9854b6717b0ce77c7f8f6c52"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "77ff37a3b9588d22642b6074a45f6a0846d642bc18b7bcdaec212fa93f87aacc1701672a7c00d517c6f0d437554f070c"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "8cec0820fb48bfae4c8c79a1cc6d1710d6c9d6528c7bebdf20a117ee452a5486"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "1a3986a8a4e682e1df605aa47476a54a8bc727434ec7d5b28d3af56eeb4313e3357e0c9f70d7f334e985bfc822f095d87b00766f0f7f7d45724ba02493ea1ac9"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-resteasy-reactive-common@2.13.7.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-resteasy-reactive-common@2.13.7.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus.resteasy.reactive",
+      "name" : "resteasy-reactive-common",
+      "version" : "2.13.7.Final",
+      "description" : "Provides, via submodules, a base configuration for JBoss project builds, as well as a derived configuration supporting multi-release JARs",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "cf789cc4c6790362371d801c73dce336"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "b1d587fc0b7da8c02bc221a7608eb9b58f43ae96"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a617b02fdfedf49df0b408c13115bcb884231b2c99817c5ea34e10c9aab91e2d"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "2ef002db601a3285ca9f713208cccd96dfc52e7a5c45d7242b08e43218fd788a4e74c84db943de194ed3eef1f18dbc6b643edeb2715b7016ebaf98c50b4d7e7e"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "4747edc74c4e62a6b42231d4505b67cf39f6c6b7d68ddc7812f130d57af20ee23a80eeba3da1848328d9977cc58c9e20"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "d4aa86a12e589df942408fd70a806178bcb28ccdb0778647d526ec9030f2936e1eaf93fcd73e945ddbdb30069bed2fb7"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "5e77640ef029e54eb91e18b21f3d3bd6de6dc2fab52c15af1d18e1800fb21d09"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "1182af70577f4a7ade89bf72adc7c77a164c571d57e81de3725a3bd9f38c56ba884335021ff63fc071f845518ce3236f29eb97f2f47f73ac01c6007401c75cff"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive-common@2.13.7.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.redhat.com/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive-common@2.13.7.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus.resteasy.reactive",
+      "name" : "resteasy-reactive-common-types",
+      "version" : "2.13.7.Final",
+      "description" : "Provides, via submodules, a base configuration for JBoss project builds, as well as a derived configuration supporting multi-release JARs",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "552957e836b3af58712fca83a33832e5"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "159eb712197ca6bcfdc1bfc04c73039de657c1ba"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "7f432023fc3bb6a38f46e454a5c8cad5a004f84368b1cbc847a41d2f264e6b61"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "9a5c3e658a29b521cc2a9fefd7c44a7b97091ad78cfe665002c10f52e16ed4f3bd133560a25db0c7f124b103df68b9faeb7ea6123a96537b84c3741c871ea761"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "c2a228c2e0c7d0f044ab353cf38a8c5e10346ff1b3213c6ea4dd22a75da305d652b5418387a919d9ce3cc46e5e9a659c"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "42e7e80fd4713a637d2084c3d517a412c41e6c0a2fbf18fea8f28e3301e4a037376105499a3c5636d39a5ede8c2430c2"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a84e91a931b422c10a64b14be98009126420c41b5e2c449a9cbc803749a97da6"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "efbb2373856c01a941170e2618551e42a131d216bff434b1c484cd58a46d95bdb4fbb5124dafd2dc8f8f33eeab8117e934a3432034561b0a52a80cb84a004584"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive-common-types@2.13.7.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.redhat.com/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive-common-types@2.13.7.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus.resteasy.reactive",
+      "name" : "resteasy-reactive-vertx",
+      "version" : "2.13.7.Final",
+      "description" : "Provides, via submodules, a base configuration for JBoss project builds, as well as a derived configuration supporting multi-release JARs",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "36c7dfd3da336629d2c0c0a7fa6eb6a2"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "8f7567787abf85bf693b2166b8d9aee8a4bf37ac"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "b238910e5a82efd0990b3c30d8769f7ba10e755b312bc39d042aa92b114bc168"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "9303d055d0a8530f1e24995489d5e4450c9b5d2920dba2b59c4fdf1d3f00a026d86d61e29291235c9ecf3f109ea428034ff4268917a7dd89de4a35458e673480"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "e807a54aed2e159ab0bc45f2acf4405b20cae83a4f8f9d772a8527580222c029fcd1b7c5fbf477b9385f12cc9d90740b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "5bf3434bd6c77ead88a1f2519df5418181a1200d0cf4eeb9ab88553b34f8a6a9764951d168fb043215982cfc504ff882"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "87aa4e10579736e85618481be155758242faaea627b11674d16e02293ba0648a"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "bdbfc95e748a2d0e08e1550a441dbb8abb69fb27d4cbd55edca888dfab873c4dc1960c8d7c072f5575836d108d565e4c3835aafd84ebc6312cfbc98495b3b34e"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive-vertx@2.13.7.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.redhat.com/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive-vertx@2.13.7.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus.resteasy.reactive",
+      "name" : "resteasy-reactive",
+      "version" : "2.13.7.Final",
+      "description" : "Provides, via submodules, a base configuration for JBoss project builds, as well as a derived configuration supporting multi-release JARs",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "2a3287df9c888431e5eceecf3909ebfd"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "4c9791c39ac6ea60ca2a8f6f1203d8b2319f993d"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "6ec784a8f8e45b96dba062c58ecd8d741484e3ca7ef214159b9e58afa66eaf08"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "a109d771762f51e1ee58b19cd735cabff18106705ed5ce6dfdacc6d155e0a80c4abc877f365a63ed6930672fccee4b4a686fc47a24b59d21299962b98eb8050d"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "02839a978bf750d9d82a7150504eddb4dbdf9f815f2569b90f946e54583855e682cb00196b5785b870da8dfae995719c"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "f59d574e8cf97b8dfe668db2e12a3f439c50760ef553f7ad433c93cb72ecd17b866f1e288029145cd3468d26fd152860"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "ad727e678b3dd2edc0800b9da898073de7062ff42c0201218d13344fa02a911a"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "132e3d9ad70b55f79955f6c17e978f5363024ec246168cfe7c28e003bf4b381baec67c5807bbb6ca4372f1e3b02216b33a4175fea7ea77f0c15da3bafafaa082"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive@2.13.7.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.redhat.com/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive@2.13.7.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "org.jboss.spec.javax.ws.rs",
+      "name" : "jboss-jaxrs-api_2.1_spec",
+      "version" : "2.0.1.Final",
+      "description" : "Jakarta API for RESTful Web Services",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "35b4d1b6b5f70f01c108c6b2349e4635"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "75cdeb26ccf87bc6f9d0f31b5ec4d80aa15b662c"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "3518db0a3980aacfdae916f0eb081d0fcefaa2076d2ba603edc779a601d2d1a4"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "32e2c300b8e03beef0245d1e52a779c4be1929e010ddd37ab6f05299f99887760b015b8e59efefebacb099947137a38c9cbceda94ff7e8b49e84fd4ac1df8e8a"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "fc45e2494021ea64942c5e48180df8ac1945cf98509fc9301c40924f0a8633f63bfb1968281f6967aa4d23d84a25aa84"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "ad9136a00c74fcc705a5950f70caa961b0df458150357036ec3a06aee25fa977368d20149976a9507efc41f89f27fc2a"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a53676703f732a68b5d0f1ceae9b4f569ffb3b1e829d47c9ce73fffc8dedfafa"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "e4a112cfbfa9e150f77bb47a38dc1449d2905bfb1ada7a237ec43a6fe053c57561cae8c9fdbe4911975d5b1a61b743c68afd7babb66bfc8a4fd94c95ebefbe5c"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "GPL-2.0-with-classpath-exception"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org/jboss-jaxrs-api_2.1_spec"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.jboss.org/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/jboss/jboss-jakarta-jaxrs-api_spec"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "org.jboss.spec.javax.xml.bind",
+      "name" : "jboss-jaxb-api_2.3_spec",
+      "version" : "2.0.0.Final",
+      "description" : "Jakarta XML Binding API",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "3f3c17761bb0bc98b82b3cfb9311660b"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "1d2b5404a556a4aeddde8a9676cec8ee01b4e0a0"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "f73f5832acef810d4d72da3b04378b6a70b72e955fdb0315591f0115c3ee701b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "c342e4fac2d42ae246e078e1b0be047f58be4ff96b4aed48e9106d49a7bffe94faeb8700db09845eab5f97cde6762ac680a012814f031f087a2f88a735eaef51"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "d726be0a754571de0681e5ab036049bf35eeb6dd0c08c1b9346c5f0b69b71fd2e240529d338f87ccac61a93efb353d71"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "3989d9601159184c50c3e76daac8004091b64d6dd43671475bb5c6c8e571fa4ed67a39c2a2beba67f5d80e1184d6e672"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "e6f7dd63be4d0a5328425d51571f939c23b4b91158ead4a0a21d0f1860fd9f0a"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "6f4c1904385aada6a39b3700eff0e69c451db87b64dca0f3a966f403af845b96468173ec81e5e82e16e9ff6205c375bed1befc26a1a2adfcae2a69c870dd7567"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.jboss.spec.javax.xml.bind/jboss-jaxb-api_2.3_spec@2.0.0.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/eclipse-ee4j/jaxb-api/jboss-jaxb-api_2.3_spec"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/jaxb-api/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jaxb-dev"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/jboss/jboss-jakarta-jaxb-api_spec.git/jboss-jaxb-api_2.3_spec"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.jboss.spec.javax.xml.bind/jboss-jaxb-api_2.3_spec@2.0.0.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-resteasy-reactive-qute",
+      "version" : "2.13.7.Final",
+      "description" : "Qute integration for RESTEasy Reactive. This extension is not compatible with the quarkus-resteasy extension, or any of the extensions that depend on it.",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "a5d5d0cd7e37a6fb9d78f53fa4fe64b1"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "0a65d9bf572afe68efea2e9a9d9a42b5309cb43a"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "fedabce3472f27474408c4cdae8005713d10c057d603cc2baea60a5fbe8d66d4"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "751aeb215c26372d6a8dae9607f2c60378b5be17000ec92aed82ff8075a3ba7e8911ef71287393f8c3ae226ac3458334d32f14aae9a5b93e35b0a67557781d45"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "888b1ab545038f401630fb4e597d8861dfbac80da6fa2934c08f33507c5b5c19b7ca35a138a72405ab972175b5c96304"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "f8e4692237d5d29642cd8627f3f88fd1b7f4b3099a2243b463ce12675791afb43c5b2f423269f14a1d232b9307cd4c56"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "e9e9ca3913e54558c4e70853b5106bbfea8dd19e3920e9dc50949823925618d3"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "1894439ddc2ba53ed0297d963600499cdf05a90cb8a2cf5d8331bbc9ce1b95855bdc770ecd18b67e99e24a78ee8c024c4c664a3e29020fcd5d51acab6971bf66"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-resteasy-reactive-qute@2.13.7.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-resteasy-reactive-qute@2.13.7.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-qute",
+      "version" : "2.13.7.Final",
+      "description" : "Offer templating support for web, email, etc in a build time, type-safe way",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "1d90d54b7874d22da857d7bb3f521047"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "f1d6cb6e5d10983d5e0d0edc79d714f008ac6697"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "c99568af24979fb58ae70b424679100f24b3562c873538008bdd736e82f84fb3"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "b643cf65dd50c1dcc75086a63d7b3c6211a5ae874c88250cadedf74fe357aa6043ab8535824e6e6b7e2f94d2db90443f5e2ddb40376b0d1133500c5003d0f86d"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ed5b653442b55bbc8c63fa2e352959ff6801c51b112ed7cfbb5e7c175a7e1bd7ddcae9f344aacf039bd22d84b5296fa2"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "e034f33a89a17e37f2a0d67aeea3a9c5271cf879d209508a73bcda6f58b2e4e32ae14b59f7dbce742bfc737709073ea4"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "cb5713b7382807875f0785cb3e6492d89a4c2ade0dbb9235523167f273809084"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "7d40944050d2dac887c0005d691502d7d585f7bcb4b75e583a12560a4896d1b98c674c6268974eec8b5356ae85fe418378bf32157377e397eac77e908792c29f"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-qute@2.13.7.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-qute@2.13.7.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus.qute",
+      "name" : "qute-core",
+      "version" : "2.13.7.Final",
+      "description" : "Provides, via submodules, a base configuration for JBoss project builds, as well as a derived configuration supporting multi-release JARs",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "883e79bebefd80243632239bbd17307e"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "c0f8001bb400ac6342a5ecedad87c658c8082ec2"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "0d009853ac7575a33fa84654994b763bda1e26841758f9debcf75ea5ea07b8ca"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "0834d6ca85c04dad0362250838a645edb5ec2f6487293fcf523302b7d6271d91e2ce6b8bad8e48bf634d9ade0d13c123836a68b589a3c98a07ff0590cc5ba019"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "9dbac202b4e92dad57b1df468da610adf223db64c1c0540f4557024eec15f43f0453e4ac8945d3db61a1e624124dec17"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "b51e50b37a77cc4b9d7730a9452974be210d08e596cc6b874a19ebffd94804b9e584a7322a93bc5a72f8e4fa515aaf5d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "8df271e4f03001f4d431a045013aa175885e1034e896f1e3245f63050e220040"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "3f2e828dc925116298ff8106c54d5364a3d7a80c350710b44500c57ba3cf8f4bd685d531025083b62f776fee14caa76dca68c365421e80cccefa4d3ff6fad2e7"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus.qute/qute-core@2.13.7.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.redhat.com/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus.qute/qute-core@2.13.7.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-vertx-http",
+      "version" : "2.13.8.Final-redhat-00006",
+      "description" : "Vert.x HTTP",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "673ae570091ff06a5c7a131d6ff8cb85"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "12da7f4458b77e0f91973e5e9cfa89b2188b06f5"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "0bd8d9832afa43215e1a5140f70750a5b7956e7acc83ac0c09126133cf9b0a99"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "ea0e5a61bbb8c767a9e813536afe99056ba47a1eb0b2debbb5579231495c166fe34b0e722a8be94b350ee2c357968770c96669eb31a462f9b000761dce223f63"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "4b473fc9b04d633bc33cf6b397ada31050518fd0f8da70432654357b6321199956f1f6b3a78102de76e16840e275634a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "0db8b5a1c750b6e80b0b74a511e87c1dee797be06db30a52d7f5183bc3425250b6747e463657be94f1a5fdfabaeb9103"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a609a1df1d1a5e1135a6ec253060249a111234dd8d800deb34e3782bc154d139"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "81d2f4ba20c1afda0190703950194c584dd2b623dcb87c34c39d722dddf8531571005f18af0432118be3257ddc394afb3b709def69c2af6b5b1dc4d67dad4cc4"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.8.Final-redhat-00006?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.8.Final-redhat-00006?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-security-runtime-spi",
+      "version" : "2.13.8.Final-redhat-00006",
+      "description" : "Build parent to bring in required dependencies",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "f65241aefbd100a649c9dd5efb604c87"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "cb4e4373a896803072617160a2a538c919575700"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "724c2fccc9d408bba6b3f3a4e60a770ba5da40851b0f084d9cb98314f87dcef5"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "774fbfafb17593284d8fb7b60ef369affe90753065d0df27649b067da11778929bc10a04d3582b93bd7c793ce7fb11db99171f8f5972d8f70f2d8c2262a1a318"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "72c70c19d1c74d5a9db5a67bc770c9dce9c8648a604d828c2a739a31ecfce8c35279a2be61c0d043884e1758c6e9d4d5"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "69b117c3be9b5dceba5c2965901d08c07fc32150011157ffaa4bd9137c712e07ffe74a0521c45bbad6f1718d5405a141"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "ad1ef0583ccb46205d853fad8bc67fd6b8a2eb80660cac408fc7588c7111cb7b"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b7635667557ee58ca2f6f4f63cc09580652b444457b35971f16ed60ba04acf8fb6214500852ae71cc21e6b422310132f755b96a2a2fd1606693e6fe1ecce525b"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-security-runtime-spi@2.13.8.Final-redhat-00006?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-security-runtime-spi@2.13.8.Final-redhat-00006?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-credentials",
+      "version" : "2.13.8.Final-redhat-00006",
+      "description" : "Build parent to bring in required dependencies",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "f91e6f073bf2d937373c1b77bfe2f859"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "ae964293a0b8212bacd02fc8c2ac0f22208159df"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "378d2e04b16b14d5be6a26b2fba53331573ab09b08a9c87f583772735f9354a7"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "ad6ee5f4f20940467f9f94e4dbd5587a7f63d361a6401f9498ea2e93917cf9c6484db826cd0d9e8d4a2dfa0892f8b5e0278cd8a175fcc6848f6034e0f7166eb2"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "b4e075c1dc35a37a6d8f647e6cc46568608430d91c7c4aba16d67a52f7889e13d3b5294f69e4ef3cd16af99b53f682c3"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "8a2857df3eda0be34d6167540008d141a4dcb1f114ae26c6ac35ee73d008ad9584ad48d40465bcecdbb10f11879d922c"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "e6ccf7a0583ce0ba3fd8e7cd7f76f4d0cb2746c8e330f0df7f2fc8545ce76d19"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "0e9860c39e2957333c1c924ca9fc7990557cd8f4d2041f91b64fa4d0353d1336de26f7245c04c597c7f188156b31ab0123a60b76efc654b3d6abfc6cba4ee60a"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-credentials@2.13.8.Final-redhat-00006?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-credentials@2.13.8.Final-redhat-00006?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-vertx-http-dev-console-runtime-spi",
+      "version" : "2.13.8.Final-redhat-00006",
+      "description" : "Build parent to bring in required dependencies",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "703dbbb8e32cdef1cf78ce17b59f2650"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a1bbaef92482f79249d725b72f82b05038f1a82f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "79fb98a99edcaec79c2a20efeeccb31440679c70753ce724704d9ada6cb1bffe"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "2525e48e4a61d178ecc6598844f962482f37c81b941dca3c042a8ff51ff654974493a7e500030fd6dace127cb31ba0f6513eba76a4b3ec93a41cf6f8d5906ba2"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "d3e3f6c54e1698ad353034a4437fcf0b2a17e2fb61a6a70202df00fb650e2377d60b370e5686707323651f663cda13bd"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "003655c3b220b86e78ecf1bd19a0efe9847fd7523f3d7286904194442647d584a4b48dca5c327ea03e7d9a7ef572bf3e"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "e06dfd703c122db39f4c610e256b1fdaf7cf88d5f9a24a80808c422f191a7df7"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "7f4b9f22964c6da065118c16e95f2c35402cdbc803460b0cb9f34b267eccd34108d5924430147612a484ee2e9609c81545db86d23aafbdb80919be0e04e11b84"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-vertx-http-dev-console-runtime-spi@2.13.8.Final-redhat-00006?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-vertx-http-dev-console-runtime-spi@2.13.8.Final-redhat-00006?type=jar"
+    },
+    {
+      "publisher" : "SmallRye",
+      "group" : "io.smallrye.reactive",
+      "name" : "smallrye-mutiny-vertx-web",
+      "version" : "2.27.0.redhat-00001",
+      "description" : "SmallRye Build Parent POM",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "6e3c7ef8c74033a51edb5412e76caff8"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "b9865c5d638045ee993f79f66abd3031ab98a013"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "9468c21fe37592ceb95e5679bbedd64bb9c25cc9a022866988ba84f5fa3860b5"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "3a144d6e9ccfb72ad60918bb92ba627bea2b2d9091b4c84a20ca5e8822da8fd4cf2d9ba8cf732ff65145a238e73f4f082b1e206804bfa7f83f761daad79f162f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "8f1b9db8e8ec1fb385573b41ad045a997259c5381ea88e52090d0554a92376ff8fb4523f1a3eed7116d8ce8f07f19b08"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "3edd3e43724e9be1d818148cd08009ab99c945170c1b5a2d2f09cfa6b5542bb39ca57e92fbf425ae0bff7f96fcb1bd93"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "bab4fcfd18b43d5ca6794f6baae4cd4e0405a213909bb09010c05f22537eda55"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "6dd06f35ee7964fbff4e9cb11d511b8f01dc27fc269eff6c21a3a9d1294416bb441802f3e7ee2a03a1723b734c22fe130e28fe76faac4502ddde99fe9de1638f"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web@2.27.0.redhat-00001?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://smallrye.io/smallrye-mutiny-vertx-bindings/vertx-mutiny-clients/smallrye-mutiny-vertx-web"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-mutiny-vertx-bindings/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-mutiny-vertx-bindings/vertx-mutiny-clients/smallrye-mutiny-vertx-web"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web@2.27.0.redhat-00001?type=jar"
+    },
+    {
+      "publisher" : "SmallRye",
+      "group" : "io.smallrye.reactive",
+      "name" : "smallrye-mutiny-vertx-web-common",
+      "version" : "2.27.0.redhat-00001",
+      "description" : "SmallRye Build Parent POM",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "b751074fcabf5504a5ecd5580e9f56c9"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "161e3317bc4b067cf9d32705a90e3683bf77927b"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "432a141c1289d3087a740d8f02c18061c39f2234c55c15e012d4146beab456a1"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "f881682ed2bad454bd610268351af4b0ea101648e6b36d9f428306754afad80102bf4c2a273904e6e0d7a7185968e063997f130415a4bd22d7e308dfe7faa9b5"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "985a768f74ba96df91acc85f707e8b4463c3fa526fb9875638e8c1789724273e81f3e1b8c781ea7fc8907e7c8aefa004"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "e5a1def5fa27c186a0cb2ee886deaf437e8e167d66106e34994efea3f91e419ca136287e92afe57922b04a6925d48cf8"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "5b889392aa6815f518b653f969b3ac888b221737191dbad0d9f050aee4c85696"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b611b698096833a4ca0a9d6bcc124b99301545ae0263d9d2a7c56e4f3b1f968e2e5ebddf555cb244037710cf94468af0b9ab13c151815dad11defb3b875c1b44"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web-common@2.27.0.redhat-00001?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://smallrye.io/smallrye-mutiny-vertx-bindings/vertx-mutiny-clients/smallrye-mutiny-vertx-web-common"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-mutiny-vertx-bindings/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-mutiny-vertx-bindings/vertx-mutiny-clients/smallrye-mutiny-vertx-web-common"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web-common@2.27.0.redhat-00001?type=jar"
+    },
+    {
+      "publisher" : "SmallRye",
+      "group" : "io.smallrye.reactive",
+      "name" : "smallrye-mutiny-vertx-auth-common",
+      "version" : "2.27.0.redhat-00001",
+      "description" : "SmallRye Build Parent POM",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "00ebd591c34c569c7c82196f3d1347be"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "d1d9383e6b15d7314ef6fde45851cebd4a94649b"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d08115f7436c6b51467677e41393a7ffd9b84341a9b4d530eda5696458e9d818"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "32696d46e294d310b28126519cb75a437b687ca2c9714511fa48dbfc02155cecededd51556292b629cbd0743a19af733379cea7aaccf59212d87bc6361d69d8c"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "e20d957b891b57ce42b878a4f7ab9410e5a97595ba6de747e817beb4b2ec86448f6933f96b616e967b4822f788fc14b7"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "802431435845596f0dad394c048cbee1f38fe13c41c261e6bd1cfffa0d86c9fbee34ae0c5325f785114b95e6b6d6bb12"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "74e52366acfe44985c0fc926fd77b817d6494d2401ebdcb32d648c690a2aa605"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "fcca9b90354d55ff563cc45a3c2e520337fddb23902cfbdd622dbd04a9f646a0e6bb4f57673936a37da2c4e36a728e2caef1b023c7bd72c97b951d99fd20bcca"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-auth-common@2.27.0.redhat-00001?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://smallrye.io/smallrye-mutiny-vertx-bindings/vertx-mutiny-clients/smallrye-mutiny-vertx-auth-common"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-mutiny-vertx-bindings/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-mutiny-vertx-bindings/vertx-mutiny-clients/smallrye-mutiny-vertx-auth-common"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-auth-common@2.27.0.redhat-00001?type=jar"
+    },
+    {
+      "publisher" : "SmallRye",
+      "group" : "io.smallrye.reactive",
+      "name" : "smallrye-mutiny-vertx-bridge-common",
+      "version" : "2.27.0.redhat-00001",
+      "description" : "SmallRye Build Parent POM",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "9415f246951d18323afaca2cff516024"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "4a2f58068c98214618f59515b8f0615324173bbb"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "c18fabc6514cf6c9722e513432165af3450423e0888ddabd324d2f61274f9d91"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "251f1f8e164810de9aac8add433124a3559a1ff1f8448c882c8f3b1e4b9ddcfa674e971dd2c0c78aeaa45cf7265fb76639cf3e69797940ea52ce724963900bbb"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "8e20f2910025cd0f52cae5d4603309badd5bc059280ebc44dd83b5edc186d13b3163c85674831b5687c3ad6f20c165fe"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "152bcd5080c0a1a6e9b61f62140f711342348ef1c0937333ed9f2d63eeffbd55105f202899ec4fe2f745f7e7cfd42aca"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "f8e18a78a569ab1ea70d5282c16e8dfafcde8ea45e713906f0ffbd3e61023721"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "f40df31bdbb98544e2321592d0b525478a772e7d3277adc3f71d43913626feb675b9538a8d30cfa9daab8889c90c419ba53745e1b0eb430c85cbbaffb2dca864"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-bridge-common@2.27.0.redhat-00001?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://smallrye.io/smallrye-mutiny-vertx-bindings/vertx-mutiny-clients/smallrye-mutiny-vertx-bridge-common"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-mutiny-vertx-bindings/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-mutiny-vertx-bindings/vertx-mutiny-clients/smallrye-mutiny-vertx-bridge-common"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-bridge-common@2.27.0.redhat-00001?type=jar"
+    },
+    {
+      "publisher" : "SmallRye",
+      "group" : "io.smallrye.reactive",
+      "name" : "smallrye-mutiny-vertx-uri-template",
+      "version" : "2.27.0.redhat-00001",
+      "description" : "SmallRye Build Parent POM",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "f4b043db16ee166e7996cc066e84799e"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a87c74134be585c3f8e52aac56c0c98a38e71fe6"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "4d90b09e7e7370ad552dec4346689f37301a527bdd289409442601d0572917e0"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "c64cc4a78ffdf68fb4aae55379fe79654b3f5a1cbddb7f83dd2847a76f5ab7b612ddf86ee72c8a52715dba473d248d19fa8db510bb8731e5710a3e74924d5c44"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "f6cb469dc85ec910c24f2705464ecd8242b0e761cdb2eaa8fea4bd4f854020032a7e77e91f91f7413cf2a33fd614cd31"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "febb67f58f7e18d0541c43f81b56b3751e21f0fe61f74a868558b876cf2162ff6fe2028ba646374628cbb8c062272740"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "3375de34177bfce4754a63a253f84d905363b28a184018ba9f26cc00b1d6e3c7"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "ad8f9a75e67811fef705bd676e69ddc1915cfb810d32eb1d0fcc3be4a78b89007f60accb1b0223f7d52d4f87f58649623c7024a2f4f78b11c531f67c3cd430b1"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-uri-template@2.27.0.redhat-00001?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://smallrye.io/smallrye-mutiny-vertx-bindings/vertx-mutiny-clients/smallrye-mutiny-vertx-uri-template"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-mutiny-vertx-bindings/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-mutiny-vertx-bindings/vertx-mutiny-clients/smallrye-mutiny-vertx-uri-template"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-uri-template@2.27.0.redhat-00001?type=jar"
+    },
+    {
+      "publisher" : "Eclipse",
+      "group" : "io.vertx",
+      "name" : "vertx-uri-template",
+      "version" : "4.3.4.redhat-00007",
+      "description" : "Sonatype helps open source projects to set up Maven repositories on https://oss.sonatype.org/",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "cd48abbe0db8682a814e898ff6d51477"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "3efaa9cc8d1d96e13fbead02ca5466d92e200da5"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d103b09b25a6e13cbac6e85b3004e5d9ac0dad46d1592424966bb0dba9d55b25"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "e8e12fd1cc41f9acd163ca072478c3e4fe1f1fbe9cd073478d059aaf1371201142f040e695f8435ee84368ad60d0b36b3da3d953ad4e64f92197eae3a0572f94"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "463d80bcc6e7e83a32ca1f70dac608c46f03f82b2080f927de4b96b6ee84c6cf3bf379b48b93ac78e63145e8e20c5a1c"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "7c56698e1df2d478a6b56907214e06c516340a77dc8c0ce1b839c1f297ea110e3ad4b6bb8226c379aac014345e0557c8"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "925582048006e9dd3f91543a453e4c4c0dd59833fc1c26d51427c78013a01eb6"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "ba3b4abe1aae20f5f267e7d74e3d094089b05dbb749422858807958d2afa7227324f6c4926433ae88167737977f7dd0a5bb708216037bd97bcd92862e6b7737c"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "EPL-1.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.vertx/vertx-uri-template@4.3.4.redhat-00007?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://nexus.sonatype.org/oss-repository-hosting.html/vertx-parent/vertx-ext/vertx-ext-parent/vertx-uri-template"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.vertx/vertx-uri-template@4.3.4.redhat-00007?type=jar"
+    },
+    {
+      "group" : "io.github.crac",
+      "name" : "org-crac",
+      "version" : "0.1.1.redhat-00002",
+      "description" : "A wrapper for OpenJDK CRaC API to build and run on any JDK",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "80c8b6a8552ed09fe41aa807e51b9b12"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "b573be35fe36b9cc7c6ce98ef0f2a3df89eb8011"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "cc65cdc7159fef3b8dd65334e1bb03b56f975fdd57be62a601421b8d74aed434"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "0b1db3e61619d2d4c1615f38cd6aeb9d89bcdc279669371da2cf8823c04b13d42d646967c61bb16994f29ea07acc67ac8a037893e4ff69dee3f0585e9f5a3e44"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "616145941196f017160fc48a9eb3d4b081ba155c6463008e41194325e62f002e67914266c04bb6ac750ad4d4fd6a8192"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "a04c4ea738323c53ffb8650dcb7466cfa0c000978fbe99385fb0f1b4ea4801ce2093b898039bdcc0d48b52a3046eecba"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "41902539e4244319aa8f302a145496c5bc3a00e8ebfe8d8434003181348a9d98"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "57a305f1783e244f13f13ef77c1f32fb3e5c33cc892838cef24f1235a2979e9da107dea5f61d25ca660f47de9163d7237628baeee654854a0047b6aacc99f10a"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-2-Clause",
+            "url" : "https://opensource.org/licenses/BSD-2-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.github.crac/org-crac@0.1.1.redhat-00002?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/crac/org.crac"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/CRaC/org.crac/tree/master"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.github.crac/org-crac@0.1.1.redhat-00002?type=jar"
+    }
+  ],
+  "dependencies" : [
+    {
+      "ref" : "pkg:maven/com.example/demo@0.0.1-SNAPSHOT?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus/quarkus-resteasy@2.13.7.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-oidc@2.13.7.Final?type=jar",
+        "pkg:maven/org.keycloak/keycloak-saml-core@1.8.1.Final?type=jar",
+        "pkg:maven/ch.qos.logback/logback-core@1.1.10?type=jar",
+        "pkg:maven/org.apache.james/apache-mime4j-storage@0.8.8?type=jar",
+        "pkg:maven/org.codehaus.jettison/jettison@1.5.0?type=jar",
+        "pkg:maven/org.springframework/spring-webmvc@6.0.6?type=jar",
+        "pkg:maven/org.keycloak/keycloak-core@16.1.0?type=jar",
+        "pkg:maven/org.springframework/spring-expression@6.0.6?type=jar",
+        "pkg:maven/org.springframework.security/spring-security-web@5.7.3?type=jar",
+        "pkg:maven/com.mysql/mysql-connector-j@8.0.32?type=jar",
+        "pkg:maven/io.vertx/vertx-web@4.3.7?type=jar",
+        "pkg:maven/commons-fileupload/commons-fileupload@1.3?type=jar",
+        "pkg:maven/org.apache.tomcat/tomcat-util@10.1.7?type=jar",
+        "pkg:maven/org.apache.tomcat/tomcat-catalina@11.0.0-M10?type=jar",
+        "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@10.1.0?type=jar",
+        "pkg:maven/log4j/log4j@1.2.17?type=jar",
+        "pkg:maven/org.zenframework.z8.dependencies.commons/log4j-1.2.17@2.0?type=jar",
+        "pkg:maven/net.sourceforge.htmlunit/htmlunit@2.69.0?type=jar",
+        "pkg:maven/io.quarkus/quarkus-grpc@3.2.0.Final?type=jar",
+        "pkg:maven/com.google.guava/guava@31.1-jre?type=jar",
+        "pkg:maven/io.undertow/undertow-servlet@2.3.6.Final?type=jar",
+        "pkg:maven/org.bouncycastle/bcprov-jdk15on@1.59?type=jar",
+        "pkg:maven/org.xerial.snappy/snappy-java@1.1.10.0?type=jar",
+        "pkg:maven/io.helidon.http/helidon-http-http2@4.0.0-RC1?type=jar",
+        "pkg:maven/io.netty/netty-codec-http2@4.1.99.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-keycloak-authorization@2.13.7.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-csrf-reactive@2.13.7.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.8.Final-redhat-00006?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-resteasy@2.13.7.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.8.Final-redhat-00006?type=jar",
+        "pkg:maven/io.quarkus/quarkus-resteasy-server-common@2.13.7.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.8.Final-redhat-00006?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus/quarkus-core@2.13.7.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-security-runtime-spi@2.13.8.Final-redhat-00006?type=jar",
+        "pkg:maven/io.quarkus/quarkus-credentials@2.13.8.Final-redhat-00006?type=jar",
+        "pkg:maven/io.quarkus/quarkus-mutiny@3.2.0.Final?type=jar",
+        "pkg:maven/io.smallrye.common/smallrye-common-vertx-context@2.1.0?type=jar",
+        "pkg:maven/io.quarkus/quarkus-vertx-http-dev-console-runtime-spi@2.13.8.Final-redhat-00006?type=jar",
+        "pkg:maven/io.quarkus.security/quarkus-security@2.0.2.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-vertx@2.13.7.Final?type=jar",
+        "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web@2.27.0.redhat-00001?type=jar",
+        "pkg:maven/io.vertx/vertx-web@4.3.7?type=jar",
+        "pkg:maven/io.github.crac/org-crac@0.1.1.redhat-00002?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-core@2.13.7.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5?type=jar",
+        "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2?type=jar",
+        "pkg:maven/jakarta.inject/jakarta.inject-api@1.0?type=jar",
+        "pkg:maven/io.quarkus/quarkus-ide-launcher@2.13.7.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-development-mode-spi@2.13.7.Final?type=jar",
+        "pkg:maven/io.smallrye.config/smallrye-config@2.12.3?type=jar",
+        "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final?type=jar",
+        "pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10?type=jar",
+        "pkg:maven/org.jboss.logging/jboss-logging-annotations@2.2.1.Final?type=jar",
+        "pkg:maven/org.jboss.threads/jboss-threads@3.4.3.Final?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.30?type=jar",
+        "pkg:maven/org.jboss.slf4j/slf4j-jboss-logmanager@1.2.0.Final?type=jar",
+        "pkg:maven/org.graalvm.sdk/graal-sdk@22.3.0?type=jar",
+        "pkg:maven/org.wildfly.common/wildfly-common@1.5.4.Final-format-001?type=jar",
+        "pkg:maven/io.quarkus/quarkus-bootstrap-runner@2.13.7.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-fs-util@0.0.9?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2?type=jar",
+      "dependsOn" : [
+        "pkg:maven/jakarta.el/jakarta.el-api@3.0.3?type=jar",
+        "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5?type=jar",
+        "pkg:maven/jakarta.inject/jakarta.inject-api@1.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/jakarta.el/jakarta.el-api@3.0.3?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5?type=jar",
+      "dependsOn" : [
+        "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/jakarta.inject/jakarta.inject-api@1.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-ide-launcher@2.13.7.Final?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-development-mode-spi@2.13.7.Final?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye.config/smallrye-config@2.12.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.smallrye.config/smallrye-config-core@2.12.3?type=jar",
+        "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye.config/smallrye-config-core@2.12.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1?type=jar",
+        "pkg:maven/io.smallrye.common/smallrye-common-annotation@2.1.0?type=jar",
+        "pkg:maven/io.smallrye.common/smallrye-common-expression@1.13.1?type=jar",
+        "pkg:maven/io.smallrye.common/smallrye-common-constraint@2.1.0?type=jar",
+        "pkg:maven/io.smallrye.common/smallrye-common-classloader@1.13.1?type=jar",
+        "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final?type=jar",
+        "pkg:maven/org.ow2.asm/asm@5.0.4?type=jar",
+        "pkg:maven/io.smallrye.config/smallrye-config-common@2.12.3?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye.common/smallrye-common-annotation@2.1.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye.common/smallrye-common-expression@1.13.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.smallrye.common/smallrye-common-function@1.13.1?type=jar",
+        "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye.common/smallrye-common-function@1.13.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.smallrye.common/smallrye-common-constraint@2.1.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye.common/smallrye-common-constraint@2.1.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye.common/smallrye-common-classloader@1.13.1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.ow2.asm/asm@5.0.4?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye.config/smallrye-config-common@2.12.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1?type=jar",
+        "pkg:maven/io.smallrye.common/smallrye-common-classloader@1.13.1?type=jar",
+        "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.wildfly.common/wildfly-common@1.5.4.Final-format-001?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.wildfly.common/wildfly-common@1.5.4.Final-format-001?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.jboss.logging/jboss-logging-annotations@2.2.1.Final?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.jboss.threads/jboss-threads@3.4.3.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final?type=jar",
+        "pkg:maven/org.wildfly.common/wildfly-common@1.5.4.Final-format-001?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.slf4j/slf4j-api@1.7.30?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.jboss.slf4j/slf4j-jboss-logmanager@1.2.0.Final?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.graalvm.sdk/graal-sdk@22.3.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-bootstrap-runner@2.13.7.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.smallrye.common/smallrye-common-io@1.13.1?type=jar",
+        "pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10?type=jar",
+        "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final?type=jar",
+        "pkg:maven/io.github.crac/org-crac@0.1.1.redhat-00002?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye.common/smallrye-common-io@1.13.1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.github.crac/org-crac@0.1.1.redhat-00002?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-fs-util@0.0.9?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-security-runtime-spi@2.13.8.Final-redhat-00006?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus/quarkus-core@2.13.7.Final?type=jar",
+        "pkg:maven/io.quarkus.security/quarkus-security@2.0.2.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus.security/quarkus-security@2.0.2.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2?type=jar",
+        "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final?type=jar",
+        "pkg:maven/io.smallrye.reactive/mutiny@2.1.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye.reactive/mutiny@2.1.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.smallrye.common/smallrye-common-annotation@2.1.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-credentials@2.13.8.Final-redhat-00006?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus.arc/arc@3.2.0.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus.arc/arc@3.2.0.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2?type=jar",
+        "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5?type=jar",
+        "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3?type=jar",
+        "pkg:maven/io.smallrye.reactive/mutiny@2.1.0?type=jar",
+        "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-mutiny@3.2.0.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus/quarkus-core@2.13.7.Final?type=jar",
+        "pkg:maven/io.smallrye.reactive/mutiny@2.1.0?type=jar",
+        "pkg:maven/io.quarkus/quarkus-smallrye-context-propagation@3.2.0.Final?type=jar",
+        "pkg:maven/io.smallrye.reactive/mutiny-smallrye-context-propagation@2.3.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-smallrye-context-propagation@3.2.0.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.smallrye/smallrye-context-propagation@2.1.0?type=jar",
+        "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2?type=jar",
+        "pkg:maven/io.quarkus/quarkus-core@2.13.7.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-arc@3.2.0.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye/smallrye-context-propagation@2.1.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.3?type=jar",
+        "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1?type=jar",
+        "pkg:maven/io.smallrye/smallrye-context-propagation-api@2.1.0?type=jar",
+        "pkg:maven/io.smallrye/smallrye-context-propagation-storage@2.1.0?type=jar",
+        "pkg:maven/org.jboss.threads/jboss-threads@3.4.3.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.3?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye/smallrye-context-propagation-api@2.1.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.3?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye/smallrye-context-propagation-storage@2.1.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-arc@3.2.0.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus.arc/arc@3.2.0.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-core@2.13.7.Final?type=jar",
+        "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.3?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye.reactive/mutiny-smallrye-context-propagation@2.3.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.3?type=jar",
+        "pkg:maven/io.smallrye.reactive/mutiny@2.1.0?type=jar",
+        "pkg:maven/io.smallrye/smallrye-context-propagation@2.1.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye.common/smallrye-common-vertx-context@2.1.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.vertx/vertx-core@4.3.7?type=jar",
+        "pkg:maven/io.smallrye.common/smallrye-common-constraint@2.1.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.vertx/vertx-core@4.3.7?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.netty/netty-common@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-buffer@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-transport@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-handler@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-handler-proxy@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-codec-http@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-codec-http2@4.1.99.Final?type=jar",
+        "pkg:maven/io.netty/netty-resolver@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-resolver-dns@4.1.53.Final?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.netty/netty-common@4.1.53.Final?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.netty/netty-buffer@4.1.53.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.netty/netty-common@4.1.53.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.netty/netty-transport@4.1.53.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.netty/netty-common@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-buffer@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-resolver@4.1.53.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.netty/netty-resolver@4.1.53.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.netty/netty-common@4.1.53.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.netty/netty-handler@4.1.53.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.netty/netty-common@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-resolver@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-buffer@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-transport@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-codec@4.1.53.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.netty/netty-codec@4.1.53.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.netty/netty-common@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-buffer@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-transport@4.1.53.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.netty/netty-handler-proxy@4.1.53.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.netty/netty-common@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-buffer@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-transport@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-codec@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-codec-socks@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-codec-http@4.1.53.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.netty/netty-codec-socks@4.1.53.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.netty/netty-common@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-buffer@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-transport@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-codec@4.1.53.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.netty/netty-codec-http@4.1.53.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.netty/netty-common@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-buffer@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-transport@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-codec@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-handler@4.1.53.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.netty/netty-codec-http2@4.1.99.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.netty/netty-common@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-buffer@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-transport@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-codec@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-handler@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-codec-http@4.1.53.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.netty/netty-resolver-dns@4.1.53.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.netty/netty-common@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-buffer@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-resolver@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-transport@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-codec@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-codec-dns@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-handler@4.1.53.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.netty/netty-codec-dns@4.1.53.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.netty/netty-common@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-buffer@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-transport@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-codec@4.1.53.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-vertx-http-dev-console-runtime-spi@2.13.8.Final-redhat-00006?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus/quarkus-core@2.13.7.Final?type=jar",
+        "pkg:maven/io.quarkus.arc/arc@3.2.0.Final?type=jar",
+        "pkg:maven/io.vertx/vertx-web@4.3.7?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.vertx/vertx-web@4.3.7?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.vertx/vertx-web-common@4.3.7?type=jar",
+        "pkg:maven/io.vertx/vertx-auth-common@4.3.7?type=jar",
+        "pkg:maven/io.vertx/vertx-bridge-common@4.3.7?type=jar",
+        "pkg:maven/io.vertx/vertx-core@4.3.7?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.vertx/vertx-web-common@4.3.7?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.vertx/vertx-core@4.3.7?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.vertx/vertx-auth-common@4.3.7?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.vertx/vertx-core@4.3.7?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.vertx/vertx-bridge-common@4.3.7?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.vertx/vertx-core@4.3.7?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-vertx@2.13.7.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus/quarkus-arc@3.2.0.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-netty@2.13.7.Final?type=jar",
+        "pkg:maven/io.netty/netty-codec-haproxy@4.1.53.Final?type=jar",
+        "pkg:maven/io.smallrye.common/smallrye-common-annotation@2.1.0?type=jar",
+        "pkg:maven/io.smallrye.common/smallrye-common-vertx-context@2.1.0?type=jar",
+        "pkg:maven/io.quarkus/quarkus-mutiny@3.2.0.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-vertx-latebound-mdc-provider@2.13.7.Final?type=jar",
+        "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0?type=jar",
+        "pkg:maven/io.smallrye/smallrye-fault-tolerance-vertx@5.5.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-netty@2.13.7.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.netty/netty-codec@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-codec-http@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-codec-http2@4.1.99.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-arc@3.2.0.Final?type=jar",
+        "pkg:maven/io.netty/netty-handler@4.1.53.Final?type=jar",
+        "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2?type=jar",
+        "pkg:maven/com.aayushatharva.brotli4j/brotli4j@1.7.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.aayushatharva.brotli4j/brotli4j@1.7.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.aayushatharva.brotli4j/native-linux-x86_64@1.7.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.aayushatharva.brotli4j/native-linux-x86_64@1.7.1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.netty/netty-codec-haproxy@4.1.53.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.netty/netty-buffer@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-transport@4.1.53.Final?type=jar",
+        "pkg:maven/io.netty/netty-codec@4.1.53.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-vertx-latebound-mdc-provider@2.13.7.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.smallrye.reactive/mutiny@2.1.0?type=jar",
+        "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@2.27.0?type=jar",
+        "pkg:maven/io.vertx/vertx-core@4.3.7?type=jar",
+        "pkg:maven/io.smallrye.reactive/vertx-mutiny-generator@2.27.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@2.27.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.smallrye.reactive/mutiny@2.1.0?type=jar",
+        "pkg:maven/io.vertx/vertx-core@4.3.7?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye.reactive/vertx-mutiny-generator@2.27.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@2.27.0?type=jar",
+        "pkg:maven/io.vertx/vertx-codegen@4.3.4?type=jar",
+        "pkg:maven/io.smallrye.common/smallrye-common-annotation@2.1.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.vertx/vertx-codegen@4.3.4?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye/smallrye-fault-tolerance-vertx@5.5.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web@2.27.0.redhat-00001?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.vertx/vertx-web@4.3.7?type=jar",
+        "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0?type=jar",
+        "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web-common@2.27.0.redhat-00001?type=jar",
+        "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-auth-common@2.27.0.redhat-00001?type=jar",
+        "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-bridge-common@2.27.0.redhat-00001?type=jar",
+        "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-uri-template@2.27.0.redhat-00001?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web-common@2.27.0.redhat-00001?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.vertx/vertx-web-common@4.3.7?type=jar",
+        "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-auth-common@2.27.0.redhat-00001?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.vertx/vertx-auth-common@4.3.7?type=jar",
+        "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-bridge-common@2.27.0.redhat-00001?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.vertx/vertx-bridge-common@4.3.7?type=jar",
+        "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-uri-template@2.27.0.redhat-00001?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.vertx/vertx-uri-template@4.3.4.redhat-00007?type=jar",
+        "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.vertx/vertx-uri-template@4.3.4.redhat-00007?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.vertx/vertx-core@4.3.7?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-resteasy-server-common@2.13.7.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus/quarkus-core@2.13.7.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-arc@3.2.0.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-resteasy-common@2.13.7.Final?type=jar",
+        "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-resteasy-common@2.13.7.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus/quarkus-core@2.13.7.Final?type=jar",
+        "pkg:maven/org.jboss.resteasy/resteasy-core@4.7.7.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-arc@3.2.0.Final?type=jar",
+        "pkg:maven/com.sun.activation/jakarta.activation@1.2.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.jboss.resteasy/resteasy-core@4.7.7.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final?type=jar",
+        "pkg:maven/org.jboss.spec.javax.annotation/jboss-annotations-api_1.3_spec@2.0.1.Final?type=jar",
+        "pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final?type=jar",
+        "pkg:maven/org.jboss.spec.javax.xml.bind/jboss-jaxb-api_2.3_spec@2.0.0.Final?type=jar",
+        "pkg:maven/org.jboss.resteasy/resteasy-core-spi@4.7.7.Final?type=jar",
+        "pkg:maven/org.reactivestreams/reactive-streams@1.0.3?type=jar",
+        "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2?type=jar",
+        "pkg:maven/com.ibm.async/asyncutil@0.1.0?type=jar",
+        "pkg:maven/io.smallrye.config/smallrye-config@2.12.3?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.jboss.spec.javax.annotation/jboss-annotations-api_1.3_spec@2.0.1.Final?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.jboss.spec.javax.xml.bind/jboss-jaxb-api_2.3_spec@2.0.0.Final?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.jboss.resteasy/resteasy-core-spi@4.7.7.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final?type=jar",
+        "pkg:maven/org.jboss.spec.javax.annotation/jboss-annotations-api_1.3_spec@2.0.1.Final?type=jar",
+        "pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final?type=jar",
+        "pkg:maven/org.jboss.spec.javax.xml.bind/jboss-jaxb-api_2.3_spec@2.0.0.Final?type=jar",
+        "pkg:maven/org.reactivestreams/reactive-streams@1.0.3?type=jar",
+        "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.reactivestreams/reactive-streams@1.0.3?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.ibm.async/asyncutil@0.1.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.sun.activation/jakarta.activation@1.2.2?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-oidc@2.13.7.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus/quarkus-core@2.13.7.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-vertx@2.13.7.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.8.Final-redhat-00006?type=jar",
+        "pkg:maven/io.quarkus/quarkus-security@2.13.7.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-jsonp@2.13.7.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-oidc-common@2.13.7.Final?type=jar",
+        "pkg:maven/io.smallrye/smallrye-jwt@3.5.4?type=jar",
+        "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-security@2.13.7.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus/quarkus-arc@3.2.0.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-security-runtime-spi@2.13.8.Final-redhat-00006?type=jar",
+        "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5?type=jar",
+        "pkg:maven/io.quarkus.security/quarkus-security@2.0.2.Final?type=jar",
+        "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-jsonp@2.13.7.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus/quarkus-core@2.13.7.Final?type=jar",
+        "pkg:maven/org.glassfish/jakarta.json@1.1.6?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.glassfish/jakarta.json@1.1.6?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-oidc-common@2.13.7.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus/quarkus-core@2.13.7.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-vertx@2.13.7.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-mutiny@3.2.0.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-credentials@2.13.8.Final-redhat-00006?type=jar",
+        "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web-client@2.27.0?type=jar",
+        "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5?type=jar",
+        "pkg:maven/io.quarkus/quarkus-smallrye-jwt-build@2.13.7.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web-client@2.27.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.vertx/vertx-web-client@4.3.4?type=jar",
+        "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0?type=jar",
+        "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-auth-common@2.27.0.redhat-00001?type=jar",
+        "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web-common@2.27.0.redhat-00001?type=jar",
+        "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-uri-template@2.27.0.redhat-00001?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.vertx/vertx-web-client@4.3.4?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.vertx/vertx-uri-template@4.3.4.redhat-00007?type=jar",
+        "pkg:maven/io.vertx/vertx-web-common@4.3.7?type=jar",
+        "pkg:maven/io.vertx/vertx-auth-common@4.3.7?type=jar",
+        "pkg:maven/io.vertx/vertx-core@4.3.7?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-smallrye-jwt-build@2.13.7.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.smallrye/smallrye-jwt-build@3.5.4?type=jar",
+        "pkg:maven/io.quarkus/quarkus-jsonp@2.13.7.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-core@2.13.7.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-arc@3.2.0.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye/smallrye-jwt-build@3.5.4?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1?type=jar",
+        "pkg:maven/org.eclipse.microprofile.jwt/microprofile-jwt-auth-api@1.2.2?type=jar",
+        "pkg:maven/org.bitbucket.b_c/jose4j@0.8.0?type=jar",
+        "pkg:maven/io.smallrye/smallrye-jwt-common@3.5.4?type=jar",
+        "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.eclipse.microprofile.jwt/microprofile-jwt-auth-api@1.2.2?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.bitbucket.b_c/jose4j@0.8.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.slf4j/slf4j-api@1.7.30?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye/smallrye-jwt-common@3.5.4?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.bitbucket.b_c/jose4j@0.8.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye/smallrye-jwt@3.5.4?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1?type=jar",
+        "pkg:maven/org.eclipse.microprofile.jwt/microprofile-jwt-auth-api@1.2.2?type=jar",
+        "pkg:maven/org.bitbucket.b_c/jose4j@0.8.0?type=jar",
+        "pkg:maven/io.smallrye/smallrye-jwt-common@3.5.4?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.keycloak/keycloak-saml-core@1.8.1.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.apache.santuario/xmlsec@1.5.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.santuario/xmlsec@1.5.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/commons-logging/commons-logging@1.1.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/commons-logging/commons-logging@1.1.1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/ch.qos.logback/logback-core@1.1.10?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.james/apache-mime4j-storage@0.8.8?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.apache.james/apache-mime4j-dom@0.8.8?type=jar",
+        "pkg:maven/commons-io/commons-io@2.11.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.james/apache-mime4j-dom@0.8.8?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.apache.james/apache-mime4j-core@0.8.8?type=jar",
+        "pkg:maven/commons-io/commons-io@2.11.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.james/apache-mime4j-core@0.8.8?type=jar",
+      "dependsOn" : [
+        "pkg:maven/commons-io/commons-io@2.11.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/commons-io/commons-io@2.11.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.codehaus.jettison/jettison@1.5.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-webmvc@6.0.6?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-aop@5.2.10.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-context@5.2.10.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-expression@6.0.6?type=jar",
+        "pkg:maven/org.springframework/spring-web@5.2.10.RELEASE?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-aop@5.2.10.RELEASE?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-jcl@5.2.10.RELEASE?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-jcl@5.2.10.RELEASE?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-context@5.2.10.RELEASE?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-aop@5.2.10.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-expression@6.0.6?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-expression@6.0.6?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-web@5.2.10.RELEASE?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.keycloak/keycloak-core@16.1.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.keycloak/keycloak-common@16.1.0?type=jar",
+        "pkg:maven/org.bouncycastle/bcprov-jdk15on@1.59?type=jar",
+        "pkg:maven/org.bouncycastle/bcpkix-jdk15on@1.68?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.11.3?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.keycloak/keycloak-common@16.1.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.bouncycastle/bcprov-jdk15on@1.59?type=jar",
+        "pkg:maven/org.bouncycastle/bcpkix-jdk15on@1.68?type=jar",
+        "pkg:maven/com.sun.activation/jakarta.activation@1.2.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.bouncycastle/bcprov-jdk15on@1.59?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.bouncycastle/bcpkix-jdk15on@1.68?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.bouncycastle/bcprov-jdk15on@1.59?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.11.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.11.3?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.11.3?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.security/spring-security-web@5.7.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework.security/spring-security-core@5.3.5.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-aop@5.2.10.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-context@5.2.10.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-expression@6.0.6?type=jar",
+        "pkg:maven/org.springframework/spring-web@5.2.10.RELEASE?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.security/spring-security-core@5.3.5.RELEASE?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-aop@5.2.10.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-context@5.2.10.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE?type=jar",
+        "pkg:maven/org.springframework/spring-expression@6.0.6?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.mysql/mysql-connector-j@8.0.32?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.google.protobuf/protobuf-java@3.21.9?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.google.protobuf/protobuf-java@3.21.9?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/commons-fileupload/commons-fileupload@1.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/commons-io/commons-io@2.11.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.tomcat/tomcat-util@10.1.7?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.apache.tomcat/tomcat-juli@10.1.7?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.tomcat/tomcat-juli@10.1.7?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.tomcat/tomcat-catalina@11.0.0-M10?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.apache.tomcat/tomcat-servlet-api@11.0.0-M10?type=jar",
+        "pkg:maven/org.apache.tomcat/tomcat-jsp-api@9.0.39?type=jar",
+        "pkg:maven/org.apache.tomcat/tomcat-juli@10.1.7?type=jar",
+        "pkg:maven/org.apache.tomcat/tomcat-annotations-api@9.0.39?type=jar",
+        "pkg:maven/org.apache.tomcat/tomcat-api@11.0.0-M10?type=jar",
+        "pkg:maven/org.apache.tomcat/tomcat-jni@11.0.0-M10?type=jar",
+        "pkg:maven/org.apache.tomcat/tomcat-coyote@11.0.0-M10?type=jar",
+        "pkg:maven/org.apache.tomcat/tomcat-util@10.1.7?type=jar",
+        "pkg:maven/org.apache.tomcat/tomcat-util-scan@11.0.0-M10?type=jar",
+        "pkg:maven/org.apache.tomcat/tomcat-jaspic-api@11.0.0-M10?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.tomcat/tomcat-servlet-api@11.0.0-M10?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.tomcat/tomcat-jsp-api@9.0.39?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.apache.tomcat/tomcat-el-api@9.0.39?type=jar",
+        "pkg:maven/org.apache.tomcat/tomcat-servlet-api@11.0.0-M10?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.tomcat/tomcat-el-api@9.0.39?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.tomcat/tomcat-annotations-api@9.0.39?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.tomcat/tomcat-api@11.0.0-M10?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.apache.tomcat/tomcat-servlet-api@11.0.0-M10?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.tomcat/tomcat-jni@11.0.0-M10?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.tomcat/tomcat-coyote@11.0.0-M10?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.apache.tomcat/tomcat-servlet-api@11.0.0-M10?type=jar",
+        "pkg:maven/org.apache.tomcat/tomcat-jni@11.0.0-M10?type=jar",
+        "pkg:maven/org.apache.tomcat/tomcat-juli@10.1.7?type=jar",
+        "pkg:maven/org.apache.tomcat/tomcat-util@10.1.7?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.tomcat/tomcat-util-scan@11.0.0-M10?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.apache.tomcat/tomcat-util@10.1.7?type=jar",
+        "pkg:maven/org.apache.tomcat/tomcat-juli@10.1.7?type=jar",
+        "pkg:maven/org.apache.tomcat/tomcat-api@11.0.0-M10?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.tomcat/tomcat-jaspic-api@11.0.0-M10?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@10.1.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.apache.tomcat/tomcat-annotations-api@9.0.39?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/log4j/log4j@1.2.17?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.zenframework.z8.dependencies.commons/log4j-1.2.17@2.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/net.sourceforge.htmlunit/htmlunit@2.69.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.apache.httpcomponents/httpmime@4.5.13?type=jar",
+        "pkg:maven/net.sourceforge.htmlunit/htmlunit-core-js@2.69.0?type=jar",
+        "pkg:maven/net.sourceforge.htmlunit/neko-htmlunit@2.69.0?type=jar",
+        "pkg:maven/net.sourceforge.htmlunit/htmlunit-cssparser@1.13.0?type=jar",
+        "pkg:maven/net.sourceforge.htmlunit/htmlunit-xpath@2.69.0?type=jar",
+        "pkg:maven/org.apache.commons/commons-lang3@3.10?type=jar",
+        "pkg:maven/org.apache.commons/commons-text@1.10.0?type=jar",
+        "pkg:maven/commons-io/commons-io@2.11.0?type=jar",
+        "pkg:maven/commons-net/commons-net@3.9.0?type=jar",
+        "pkg:maven/commons-codec/commons-codec@1.14?type=jar",
+        "pkg:maven/org.brotli/dec@0.1.2?type=jar",
+        "pkg:maven/com.shapesecurity/salvation2@3.0.1?type=jar",
+        "pkg:maven/org.eclipse.jetty.websocket/websocket-client@9.4.33.v20201020?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.httpcomponents/httpmime@4.5.13?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.apache.httpcomponents/httpclient@4.5.13?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.httpcomponents/httpclient@4.5.13?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.apache.httpcomponents/httpcore@4.4.13?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.httpcomponents/httpcore@4.4.13?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/net.sourceforge.htmlunit/htmlunit-core-js@2.69.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/net.sourceforge.htmlunit/neko-htmlunit@2.69.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/net.sourceforge.htmlunit/htmlunit-cssparser@1.13.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/net.sourceforge.htmlunit/htmlunit-xpath@2.69.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.commons/commons-lang3@3.10?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.commons/commons-text@1.10.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/commons-net/commons-net@3.9.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/commons-codec/commons-codec@1.14?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.brotli/dec@0.1.2?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.shapesecurity/salvation2@3.0.1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.eclipse.jetty.websocket/websocket-client@9.4.33.v20201020?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.eclipse.jetty/jetty-client@9.4.33.v20201020?type=jar",
+        "pkg:maven/org.eclipse.jetty/jetty-xml@9.4.33.v20201020?type=jar",
+        "pkg:maven/org.eclipse.jetty/jetty-util@9.4.33.v20201020?type=jar",
+        "pkg:maven/org.eclipse.jetty/jetty-io@9.4.33.v20201020?type=jar",
+        "pkg:maven/org.eclipse.jetty.websocket/websocket-common@9.4.33.v20201020?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.eclipse.jetty/jetty-client@9.4.33.v20201020?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.eclipse.jetty/jetty-http@9.4.33.v20201020?type=jar",
+        "pkg:maven/org.eclipse.jetty/jetty-io@9.4.33.v20201020?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.eclipse.jetty/jetty-http@9.4.33.v20201020?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.eclipse.jetty/jetty-util@9.4.33.v20201020?type=jar",
+        "pkg:maven/org.eclipse.jetty/jetty-io@9.4.33.v20201020?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.eclipse.jetty/jetty-util@9.4.33.v20201020?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.eclipse.jetty/jetty-io@9.4.33.v20201020?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.eclipse.jetty/jetty-util@9.4.33.v20201020?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.eclipse.jetty/jetty-xml@9.4.33.v20201020?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.eclipse.jetty/jetty-util@9.4.33.v20201020?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.eclipse.jetty.websocket/websocket-common@9.4.33.v20201020?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.eclipse.jetty.websocket/websocket-api@9.4.33.v20201020?type=jar",
+        "pkg:maven/org.eclipse.jetty/jetty-util@9.4.33.v20201020?type=jar",
+        "pkg:maven/org.eclipse.jetty/jetty-io@9.4.33.v20201020?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.eclipse.jetty.websocket/websocket-api@9.4.33.v20201020?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-grpc@3.2.0.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5?type=jar",
+        "pkg:maven/io.quarkus/quarkus-grpc-api@3.2.0.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-grpc-common@3.2.0.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.8.Final-redhat-00006?type=jar",
+        "pkg:maven/io.quarkus/quarkus-core@2.13.7.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-arc@3.2.0.Final?type=jar",
+        "pkg:maven/io.quarkus.security/quarkus-security@2.0.2.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-smallrye-stork@3.2.0.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-grpc-stubs@3.2.0.Final?type=jar",
+        "pkg:maven/io.grpc/grpc-stub@1.56.0?type=jar",
+        "pkg:maven/io.quarkus/quarkus-mutiny@3.2.0.Final?type=jar",
+        "pkg:maven/io.smallrye.common/smallrye-common-annotation@2.1.0?type=jar",
+        "pkg:maven/io.smallrye.common/smallrye-common-vertx-context@2.1.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-grpc-api@3.2.0.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus/quarkus-arc@3.2.0.Final?type=jar",
+        "pkg:maven/io.grpc/grpc-stub@1.56.0?type=jar",
+        "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.grpc/grpc-stub@1.56.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.grpc/grpc-api@1.50.2?type=jar",
+        "pkg:maven/com.google.guava/guava@31.1-jre?type=jar",
+        "pkg:maven/com.google.errorprone/error_prone_annotations@2.11.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.grpc/grpc-api@1.50.2?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.grpc/grpc-context@1.50.2?type=jar",
+        "pkg:maven/com.google.guava/guava@31.1-jre?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.grpc/grpc-context@1.50.2?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.google.guava/guava@31.1-jre?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.google.guava/failureaccess@1.0.1?type=jar",
+        "pkg:maven/com.google.guava/listenablefuture@9999.0-empty-to-avoid-conflict-with-guava?type=jar",
+        "pkg:maven/com.google.code.findbugs/jsr305@3.0.2?type=jar",
+        "pkg:maven/org.checkerframework/checker-qual@3.12.0?type=jar",
+        "pkg:maven/com.google.errorprone/error_prone_annotations@2.11.0?type=jar",
+        "pkg:maven/com.google.j2objc/j2objc-annotations@1.3?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.google.guava/failureaccess@1.0.1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.google.guava/listenablefuture@9999.0-empty-to-avoid-conflict-with-guava?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.google.code.findbugs/jsr305@3.0.2?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.checkerframework/checker-qual@3.12.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.google.errorprone/error_prone_annotations@2.11.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.google.j2objc/j2objc-annotations@1.3?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-grpc-common@3.2.0.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.google.code.findbugs/jsr305@3.0.2?type=jar",
+        "pkg:maven/io.vertx/vertx-grpc@4.4.4?type=jar",
+        "pkg:maven/io.vertx/vertx-grpc-server@4.4.4?type=jar",
+        "pkg:maven/io.vertx/vertx-grpc-client@4.4.4?type=jar",
+        "pkg:maven/io.quarkus/quarkus-vertx@2.13.7.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.vertx/vertx-grpc@4.4.4?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.vertx/vertx-core@4.3.7?type=jar",
+        "pkg:maven/io.grpc/grpc-netty@1.50.2?type=jar",
+        "pkg:maven/io.grpc/grpc-protobuf@1.50.2?type=jar",
+        "pkg:maven/io.grpc/grpc-stub@1.56.0?type=jar",
+        "pkg:maven/com.google.guava/guava@31.1-jre?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.grpc/grpc-netty@1.50.2?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.grpc/grpc-core@1.50.2?type=jar",
+        "pkg:maven/io.perfmark/perfmark-api@0.25.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.grpc/grpc-core@1.50.2?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.grpc/grpc-api@1.50.2?type=jar",
+        "pkg:maven/com.google.code.gson/gson@2.8.6?type=jar",
+        "pkg:maven/io.perfmark/perfmark-api@0.25.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.google.code.gson/gson@2.8.6?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.perfmark/perfmark-api@0.25.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.grpc/grpc-protobuf@1.50.2?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.grpc/grpc-api@1.50.2?type=jar",
+        "pkg:maven/com.google.protobuf/protobuf-java@3.21.9?type=jar",
+        "pkg:maven/com.google.api.grpc/proto-google-common-protos@2.9.0?type=jar",
+        "pkg:maven/io.grpc/grpc-protobuf-lite@1.50.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.google.api.grpc/proto-google-common-protos@2.9.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.google.protobuf/protobuf-java@3.21.9?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.grpc/grpc-protobuf-lite@1.50.2?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.grpc/grpc-api@1.50.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.vertx/vertx-grpc-server@4.4.4?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.vertx/vertx-grpc-common@4.4.4?type=jar",
+        "pkg:maven/io.grpc/grpc-stub@1.56.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.vertx/vertx-grpc-common@4.4.4?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.vertx/vertx-core@4.3.7?type=jar",
+        "pkg:maven/io.grpc/grpc-protobuf@1.50.2?type=jar",
+        "pkg:maven/io.grpc/grpc-api@1.50.2?type=jar",
+        "pkg:maven/com.google.guava/guava@31.1-jre?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.vertx/vertx-grpc-client@4.4.4?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.vertx/vertx-grpc-common@4.4.4?type=jar",
+        "pkg:maven/io.grpc/grpc-stub@1.56.0?type=jar",
+        "pkg:maven/io.grpc/grpc-api@1.50.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-smallrye-stork@3.2.0.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.smallrye.stork/stork-api@2.2.0?type=jar",
+        "pkg:maven/io.smallrye.stork/stork-core@2.2.0?type=jar",
+        "pkg:maven/io.quarkus/quarkus-core@2.13.7.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-arc@3.2.0.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-vertx@2.13.7.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye.stork/stork-api@2.2.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.smallrye.reactive/mutiny@2.1.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.smallrye.stork/stork-core@2.2.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.smallrye.stork/stork-api@2.2.0?type=jar",
+        "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@1.7.30?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-grpc-stubs@3.2.0.Final?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.undertow/undertow-servlet@2.3.6.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.undertow/undertow-core@2.1.4.Final?type=jar",
+        "pkg:maven/jakarta.servlet/jakarta.servlet-api@4.0.4?type=jar",
+        "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.undertow/undertow-core@2.1.4.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final?type=jar",
+        "pkg:maven/org.jboss.xnio/xnio-api@3.8.0.Final?type=jar",
+        "pkg:maven/org.jboss.xnio/xnio-nio@3.8.0.Final?type=jar",
+        "pkg:maven/org.jboss.threads/jboss-threads@3.4.3.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.jboss.xnio/xnio-api@3.8.0.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.wildfly.common/wildfly-common@1.5.4.Final-format-001?type=jar",
+        "pkg:maven/org.wildfly.client/wildfly-client-config@1.0.1.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.wildfly.client/wildfly-client-config@1.0.1.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final?type=jar",
+        "pkg:maven/org.wildfly.common/wildfly-common@1.5.4.Final-format-001?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.jboss.xnio/xnio-nio@3.8.0.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.jboss.xnio/xnio-api@3.8.0.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/jakarta.servlet/jakarta.servlet-api@4.0.4?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.xerial.snappy/snappy-java@1.1.10.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.helidon.http/helidon-http-http2@4.0.0-RC1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.helidon.http/helidon-http@4.0.0-RC1?type=jar",
+        "pkg:maven/io.helidon.common/helidon-common-socket@4.0.0-RC1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.helidon.http/helidon-http@4.0.0-RC1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.helidon.common/helidon-common@4.0.0-RC1?type=jar",
+        "pkg:maven/io.helidon.common/helidon-common-configurable@4.0.0-RC1?type=jar",
+        "pkg:maven/io.helidon.common/helidon-common-buffers@4.0.0-RC1?type=jar",
+        "pkg:maven/io.helidon.common/helidon-common-mapper@4.0.0-RC1?type=jar",
+        "pkg:maven/io.helidon.common/helidon-common-media-type@4.0.0-RC1?type=jar",
+        "pkg:maven/io.helidon.common/helidon-common-uri@4.0.0-RC1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.helidon.common/helidon-common@4.0.0-RC1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.helidon.common/helidon-common-configurable@4.0.0-RC1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.helidon.common/helidon-common@4.0.0-RC1?type=jar",
+        "pkg:maven/io.helidon.common/helidon-common-context@4.0.0-RC1?type=jar",
+        "pkg:maven/io.helidon.common/helidon-common-config@4.0.0-RC1?type=jar",
+        "pkg:maven/io.helidon.builder/helidon-builder-api@4.0.0-RC1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.helidon.common/helidon-common-context@4.0.0-RC1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.helidon.common/helidon-common@4.0.0-RC1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.helidon.common/helidon-common-config@4.0.0-RC1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.helidon.common/helidon-common@4.0.0-RC1?type=jar",
+        "pkg:maven/io.helidon.common/helidon-common-mapper@4.0.0-RC1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.helidon.common/helidon-common-mapper@4.0.0-RC1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.helidon.common/helidon-common@4.0.0-RC1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.helidon.builder/helidon-builder-api@4.0.0-RC1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.helidon.common/helidon-common@4.0.0-RC1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.helidon.common/helidon-common-buffers@4.0.0-RC1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.helidon.common/helidon-common@4.0.0-RC1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.helidon.common/helidon-common-media-type@4.0.0-RC1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.helidon.common/helidon-common@4.0.0-RC1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.helidon.common/helidon-common-uri@4.0.0-RC1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.helidon.common/helidon-common-parameters@4.0.0-RC1?type=jar",
+        "pkg:maven/io.helidon.builder/helidon-builder-api@4.0.0-RC1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.helidon.common/helidon-common-parameters@4.0.0-RC1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.helidon.common/helidon-common@4.0.0-RC1?type=jar",
+        "pkg:maven/io.helidon.common/helidon-common-mapper@4.0.0-RC1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.helidon.common/helidon-common-socket@4.0.0-RC1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.helidon.common/helidon-common-buffers@4.0.0-RC1?type=jar",
+        "pkg:maven/io.helidon.common/helidon-common-config@4.0.0-RC1?type=jar",
+        "pkg:maven/io.helidon.builder/helidon-builder-api@4.0.0-RC1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-keycloak-authorization@2.13.7.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus/quarkus-oidc@2.13.7.Final?type=jar",
+        "pkg:maven/org.keycloak/keycloak-adapter-core@19.0.1?type=jar",
+        "pkg:maven/org.keycloak/keycloak-core@16.1.0?type=jar",
+        "pkg:maven/com.sun.activation/jakarta.activation@1.2.2?type=jar",
+        "pkg:maven/org.keycloak/keycloak-adapter-spi@19.0.1?type=jar",
+        "pkg:maven/org.keycloak/keycloak-authz-client@19.0.1?type=jar",
+        "pkg:maven/io.quarkus/quarkus-apache-httpclient@2.13.7.Final?type=jar",
+        "pkg:maven/org.jboss.logging/commons-logging-jboss-logging@1.0.0.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.keycloak/keycloak-adapter-core@19.0.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.keycloak/keycloak-crypto-default@19.0.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.keycloak/keycloak-crypto-default@19.0.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.keycloak/keycloak-core@16.1.0?type=jar",
+        "pkg:maven/org.bouncycastle/bcprov-jdk15on@1.59?type=jar",
+        "pkg:maven/org.bouncycastle/bcpkix-jdk15on@1.68?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.keycloak/keycloak-adapter-spi@19.0.1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.keycloak/keycloak-authz-client@19.0.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.keycloak/keycloak-core@16.1.0?type=jar",
+        "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final?type=jar",
+        "pkg:maven/org.apache.httpcomponents/httpclient@4.5.13?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-apache-httpclient@2.13.7.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus/quarkus-arc@3.2.0.Final?type=jar",
+        "pkg:maven/org.apache.httpcomponents/httpclient@4.5.13?type=jar",
+        "pkg:maven/org.jboss.logging/commons-logging-jboss-logging@1.0.0.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.jboss.logging/commons-logging-jboss-logging@1.0.0.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-csrf-reactive@2.13.7.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus/quarkus-core@2.13.7.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-arc@3.2.0.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.8.Final-redhat-00006?type=jar",
+        "pkg:maven/io.quarkus/quarkus-resteasy-reactive@2.13.7.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-resteasy-reactive-qute@2.13.7.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-resteasy-reactive@2.13.7.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus/quarkus-resteasy-reactive-common@2.13.7.Final?type=jar",
+        "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive-vertx@2.13.7.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.8.Final-redhat-00006?type=jar",
+        "pkg:maven/io.quarkus/quarkus-jsonp@2.13.7.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-resteasy-reactive-common@2.13.7.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive-common@2.13.7.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-mutiny@3.2.0.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-vertx@2.13.7.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-jsonp@2.13.7.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive-common@2.13.7.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive-common-types@2.13.7.Final?type=jar",
+        "pkg:maven/io.smallrye.reactive/mutiny@2.1.0?type=jar",
+        "pkg:maven/io.smallrye.common/smallrye-common-annotation@2.1.0?type=jar",
+        "pkg:maven/org.glassfish/jakarta.json@1.1.6?type=jar",
+        "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2?type=jar",
+        "pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final?type=jar",
+        "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5?type=jar",
+        "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive-common-types@2.13.7.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive-vertx@2.13.7.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.vertx/vertx-web@4.3.7?type=jar",
+        "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0?type=jar",
+        "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive@2.13.7.Final?type=jar",
+        "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2?type=jar",
+        "pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final?type=jar",
+        "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5?type=jar",
+        "pkg:maven/org.jboss.logging/commons-logging-jboss-logging@1.0.0.Final?type=jar",
+        "pkg:maven/org.jboss.spec.javax.xml.bind/jboss-jaxb-api_2.3_spec@2.0.0.Final?type=jar",
+        "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive@2.13.7.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus.resteasy.reactive/resteasy-reactive-common@2.13.7.Final?type=jar",
+        "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2?type=jar",
+        "pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final?type=jar",
+        "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5?type=jar",
+        "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-resteasy-reactive-qute@2.13.7.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus/quarkus-core@2.13.7.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-arc@3.2.0.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-resteasy-reactive@2.13.7.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-qute@2.13.7.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-qute@2.13.7.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus/quarkus-core@2.13.7.Final?type=jar",
+        "pkg:maven/io.quarkus/quarkus-arc@3.2.0.Final?type=jar",
+        "pkg:maven/io.quarkus.qute/qute-core@2.13.7.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus.qute/qute-core@2.13.7.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final?type=jar",
+        "pkg:maven/io.smallrye.reactive/mutiny@2.1.0?type=jar"
+      ]
+    }
+  ]
+}

--- a/pkg/assembler/backends/ent/backend/hasMetadata.go
+++ b/pkg/assembler/backends/ent/backend/hasMetadata.go
@@ -79,7 +79,7 @@ func (b *EntBackend) IngestBulkHasMetadata(ctx context.Context, subjects model.P
 				results[index] = hm.ID
 				return err
 			} else {
-				return gqlerror.Errorf("IngestBulkHasMetadata failed with element #%v %+v with err: %v", i, *subject.Package, err)
+				return gqlerror.Errorf("IngestBulkHasMetadata failed with element #%v %+v with err: %v", index, *subject.Package, err)
 			}
 		})
 	}

--- a/pkg/assembler/backends/ent/packageversion/qualifier_predicates.go
+++ b/pkg/assembler/backends/ent/packageversion/qualifier_predicates.go
@@ -44,6 +44,13 @@ func QualifiersContains(key, value string) func(*sql.Selector) {
 	}
 }
 
+// QualifiersSizeMatch checks the size of the qualifiers array is the expected one
+func QualifiersSizeMatch(size int) func(*sql.Selector) {
+	return func(s *sql.Selector) {
+		s.Where(sqljson.LenEQ(FieldQualifiers, size))
+	}
+}
+
 // QualifiersMatch constructs a JSON field query for the given qualifiers.
 // If the value is nil, it will query for the key only.
 // If the value is not nil, it will query for the key/value pair.
@@ -66,5 +73,6 @@ func QualifiersMatch(spec []*model.PackageQualifierSpec, matchOnlyEmptyQualifier
 				QualifiersContains(q.Key, *q.Value)(s)
 			}
 		}
+		QualifiersSizeMatch(len(spec))(s)
 	}
 }


### PR DESCRIPTION
# Description of the PR

The issue happens when:

1. package `pkg:maven/io.github.crac/org-crac@0.1.1.redhat-00002?repository_url=https://maven.repository.redhat.com/ga/&type=jar` is ingested from Quarkus SBOM
2. package `pkg:maven/io.github.crac/org-crac@0.1.1.redhat-00002?type=jar` is ingested from SBOM "B": this ingestion fails with the error
    ```
    ingestBulkHasMetadata failed with error: HasMetadataPkgs - specific version failed with error: input: ingestBulkHasMetadata IngestBulkHasMetadata failed with element #42 {Type:maven Namespace:0xc00120e2c0 Name:org-crac Version:0xc00120e2f0 Qualifiers:[0xc001315f80] Subpath:0xc00120e340} with err: failed to execute IngestHasMetadata :: failed to retrieve subject package version :: ent: package_version not singular
    ```

It's due to the fact that, when adding an `HasMetadata` node, there's a uniqueness check for the package specs to identify a single package. In the scenario described above, both packages `pkg:maven/io.github.crac/org-crac@0.1.1.redhat-00002?repository_url=https://maven.repository.redhat.com/ga/&type=jar`  and  `pkg:maven/io.github.crac/org-crac@0.1.1.redhat-00002?type=jar` have been already ingested and the `QualifiersMatch` method checks for the provided qualifiers into the DB, i.e. `type=jar`, hence finding both the packages that satisfy this condition and hence generating the error.

The fix adds a further check that, after having checked all of input package spec qualifiers are available, it also checks the size of the array of the qualifiers to ensure package with a superset of the input qualifiers, e.g. `repository_url=https://maven.repository.redhat.com/ga/`, aren't considered as a valid matching package.

I've added a further integration test that loads the SBOM "B" for reproducing this issue with a query to check the `HasMetadata` info is available.

Fixes https://issues.redhat.com/browse/TC-1609

"Bonus fix": the log entry `IngestBulkHasMetadata failed with element` was erroneously using `i` instead of `index`

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
