### PR TITLE
Fix e2e FindDependentProduct test

### DIFF
--- a/internal/testing/e2e-trustification/e2e
+++ b/internal/testing/e2e-trustification/e2e
@@ -75,7 +75,7 @@ diff -u "${SCRIPT_DIR}/expectFindVulnerabilitySbomURI_ubi8.json" "${GUAC_DIR}/go
 cat ./demo/graphql/queries-trustification.gql | gql-cli http://localhost:8080/query -o FindRelatedProducts | jq 'del(.. | .id?) | del(.. | .origin?) | .findTopLevelPackagesRelatedToVulnerability[] | length' > "${GUAC_DIR}/gotFindRelatedProducts.json"
 diff -u "${SCRIPT_DIR}/expectFindRelatedProducts.json" "${GUAC_DIR}/gotFindRelatedProducts.json"
 
-cat ./demo/graphql/queries-trustification.gql | gql-cli http://localhost:8080/query -o FindDependentProduct | jq 'del(.. | .id?) | del(.. | .downloadLocation?) | .findDependentProduct' > "${GUAC_DIR}/gotFindDependentProduct.json"
+cat ./demo/graphql/queries-trustification.gql | gql-cli http://localhost:8080/query -o FindDependentProduct | jq 'del(.. | .id?) | del(.. | .downloadLocation?) | .findDependentProduct | sort_by(.digest)' > "${GUAC_DIR}/gotFindDependentProduct.json"
 diff -u "${SCRIPT_DIR}/expectFindDependentProduct.json" "${GUAC_DIR}/gotFindDependentProduct.json"
 
 cat ./demo/graphql/queries-trustification.gql | gql-cli http://localhost:8080/query -o HasSBOM | jq ' .HasSBOM |= sort ' > "${GUAC_DIR}/gotHasSBOM.json"


### PR DESCRIPTION
# Description of the PR

Fix the (sometimes) broken e2e `FindDependentProduct` test by sorting the results to give consistency to the response.

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
