### PR TITLE
TC-1689 Add parser for CSAF VEX RH files

### DIFF
--- a/demo/graphql/queries-trustification.gql
+++ b/demo/graphql/queries-trustification.gql
@@ -380,3 +380,20 @@ query TC_1609_HasMetadata {
     }
   }
 }
+
+query CVE_2023_1664 {
+  CertifyVEXStatement (
+    certifyVEXStatementSpec: {
+      vulnerability: {
+        vulnerabilityID: "cve-2023-1664"
+      }
+      subject: {
+        package: {
+          name: "keycloak-core"
+        }
+      }
+    }
+  ) {
+    documentRef
+  }
+}

--- a/internal/testing/e2e-trustification/e2e
+++ b/internal/testing/e2e-trustification/e2e
@@ -63,6 +63,15 @@ queries="${GUAC_DIR}/demo/graphql/queries-trustification.gql"
 
 echo @@@@ Running queries and validating output
 
+cat ./demo/graphql/queries-trustification.gql | gql-cli http://localhost:8080/query -o HasSBOM | jq ' .HasSBOM |= sort ' > "${GUAC_DIR}/gotHasSBOM.json"
+diff -u "${SCRIPT_DIR}/expectHasSBOM.json" "${GUAC_DIR}/gotHasSBOM.json"
+
+cat ./demo/graphql/queries-trustification.gql | gql-cli http://localhost:8080/query -o Vulnerabilities | jq ' .vulnerabilities[].vulnerabilityIDs |= sort_by(.vulnerabilityID) ' > "${GUAC_DIR}/gotVulnerabilities.json"
+diff -u "${SCRIPT_DIR}/expectVulnerabilities.json" "${GUAC_DIR}/gotVulnerabilities.json"
+
+cat ./demo/graphql/queries-trustification.gql | gql-cli http://localhost:8080/query -o CVE_2023_1664 | jq . > "${GUAC_DIR}/gotCVE_2023_1664.json"
+diff -u "${SCRIPT_DIR}/expectCVE_2023_1664.json" "${GUAC_DIR}/gotCVE_2023_1664.json"
+
 cat "$queries" | gql-cli http://localhost:8080/query -o FindVulnerabilitySbomURI_quarkus | jq --sort-keys 'del(.. | .id?) | del(.. | .origin?) | .findVulnerabilityBySbomURI |= sort | .findVulnerabilityBySbomURI[].subject.namespaces[]?.names[]?.versions[]?.qualifiers? |= sort' > "${GUAC_DIR}/gotFindVulnerabilitySbomURI_quarkus.json"
 diff -u "${SCRIPT_DIR}/expectFindVulnerabilitySbomURI_quarkus.json" "${GUAC_DIR}/gotFindVulnerabilitySbomURI_quarkus.json"
 
@@ -77,12 +86,6 @@ diff -u "${SCRIPT_DIR}/expectFindRelatedProducts.json" "${GUAC_DIR}/gotFindRelat
 
 cat ./demo/graphql/queries-trustification.gql | gql-cli http://localhost:8080/query -o FindDependentProduct | jq 'del(.. | .id?) | del(.. | .downloadLocation?) | .findDependentProduct | sort_by(.digest)' > "${GUAC_DIR}/gotFindDependentProduct.json"
 diff -u "${SCRIPT_DIR}/expectFindDependentProduct.json" "${GUAC_DIR}/gotFindDependentProduct.json"
-
-cat ./demo/graphql/queries-trustification.gql | gql-cli http://localhost:8080/query -o HasSBOM | jq ' .HasSBOM |= sort ' > "${GUAC_DIR}/gotHasSBOM.json"
-diff -u "${SCRIPT_DIR}/expectHasSBOM.json" "${GUAC_DIR}/gotHasSBOM.json"
-
-cat ./demo/graphql/queries-trustification.gql | gql-cli http://localhost:8080/query -o Vulnerabilities | jq ' .vulnerabilities[].vulnerabilityIDs |= sort_by(.vulnerabilityID) ' > "${GUAC_DIR}/gotVulnerabilities.json"
-diff -u "${SCRIPT_DIR}/expectVulnerabilities.json" "${GUAC_DIR}/gotVulnerabilities.json"
 
 echo @@@@ Ingesting TC_1593_sbom.json into server
 time go run ./cmd/guacone collect files ${GUAC_DIR}/internal/testing/testdata/exampledata/TC_1593_sbom.json;

--- a/internal/testing/e2e-trustification/expectCVE_2023_1664.json
+++ b/internal/testing/e2e-trustification/expectCVE_2023_1664.json
@@ -1,0 +1,7 @@
+{
+  "CertifyVEXStatement": [
+    {
+      "documentRef": "sha256_bcb4eb22af2714f0f4fcc5acd58d4d9ef48290212816c7ad776fc50e716d93a2"
+    }
+  ]
+}

--- a/pkg/assembler/clients/helpers/graphql.go
+++ b/pkg/assembler/clients/helpers/graphql.go
@@ -1,0 +1,37 @@
+package helpers
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/Khan/genqlient/graphql"
+	"github.com/spf13/viper"
+)
+
+func GetGqlClient(graphqlEndpoint string) (graphql.Client, error) {
+	httpClient := http.Client{}
+	certFile := viper.GetString("gql-tls-root-ca")
+	insecure := viper.GetBool("gql-tls-insecure")
+	if certFile != "" {
+		caCert, err := os.ReadFile(certFile)
+		if err != nil {
+			return nil, fmt.Errorf("unable to read root certificate: %v", err)
+		}
+		caCertPool := x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM(caCert)
+
+		httpClient = http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					RootCAs:            caCertPool,
+					InsecureSkipVerify: insecure,
+				},
+			},
+		}
+	}
+
+	return graphql.NewClient(graphqlEndpoint, &httpClient), nil
+}

--- a/pkg/handler/processor/guesser/type_csaf_redhat.go
+++ b/pkg/handler/processor/guesser/type_csaf_redhat.go
@@ -1,0 +1,37 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package guesser
+
+import (
+	"github.com/guacsec/guac/pkg/handler/processor"
+	"github.com/openvex/go-vex/pkg/csaf"
+)
+
+type csafRedHatTypeGuesser struct{}
+
+func (_ *csafRedHatTypeGuesser) GuessDocumentType(blob []byte, format processor.FormatType) processor.DocumentType {
+	switch format {
+	case processor.FormatJSON:
+		// Decode the BOM
+		var decoded csaf.CSAF
+		err := json.Unmarshal(blob, &decoded)
+		// TODO fix the check once decoded.Document.Publisher will be available
+		if err == nil && decoded.Document.Tracking.ID != "" /*&& decoded.Document.Publisher.Namespace*/ {
+			return processor.DocumentCsaf
+		}
+	}
+	return processor.DocumentUnknown
+}

--- a/pkg/handler/processor/guesser/type_guesser.go
+++ b/pkg/handler/processor/guesser/type_guesser.go
@@ -29,7 +29,10 @@ func init() {
 	_ = RegisterDocumentTypeGuesser(&cycloneDXTypeGuesser{}, "cyclonedx")
 	_ = RegisterDocumentTypeGuesser(&openVexTypeGuesser{}, "openvex")
 	_ = RegisterDocumentTypeGuesser(&depsDevTypeGuesser{}, "deps.dev")
-	_ = RegisterDocumentTypeGuesser(&csafTypeGuesser{}, "csaf")
+	// TODO restore the exepcted type guesser for `csaf` once the csafRedHatTypeGuesser will for fine
+	//_ = RegisterDocumentTypeGuesser(&csafTypeGuesser{}, "csaf")
+	_ = RegisterDocumentTypeGuesser(&csafRedHatTypeGuesser{}, "csaf")
+	_ = RegisterDocumentTypeGuesser(&csafRedHatTypeGuesser{}, "csaf-rh")
 }
 
 // DocumentTypeGuesser guesses the document type based on the blob and format given

--- a/pkg/handler/processor/processor.go
+++ b/pkg/handler/processor/processor.go
@@ -66,6 +66,7 @@ const (
 	DocumentCycloneDX        DocumentType = "CycloneDX"
 	DocumentDepsDev          DocumentType = "DEPS_DEV"
 	DocumentCsaf             DocumentType = "CSAF"
+	DocumentCsafRedHat       DocumentType = "CSAF-RH"
 	DocumentOpenVEX          DocumentType = "OPEN_VEX"
 	DocumentIngestPredicates DocumentType = "INGEST_PREDICATES"
 	DocumentUnknown          DocumentType = "UNKNOWN"

--- a/pkg/ingestor/ingestor.go
+++ b/pkg/ingestor/ingestor.go
@@ -46,7 +46,7 @@ func Ingest(
 	logger := d.ChildLogger
 	// Get pipeline of components
 	processorFunc := GetProcessor(ctx)
-	ingestorFunc := GetIngestor(ctx)
+	ingestorFunc := GetIngestor(context.WithValue(ctx, parser_common.KeyGraphqlEndpoint, graphqlEndpoint))
 	collectSubEmitFunc := GetCollectSubEmit(ctx, csubClient)
 	assemblerFunc := GetAssembler(ctx, d.ChildLogger, graphqlEndpoint, transport)
 
@@ -54,7 +54,7 @@ func Ingest(
 
 	docTree, err := processorFunc(d)
 	if err != nil {
-		return fmt.Errorf("unable to process doc: %v, format: %v, document: %v", err, d.Format, d.Type)
+		return fmt.Errorf("unable to process doc: %v, format: %v, document: %v, source: %v", err, d.Format, d.Type, d.SourceInformation)
 	}
 
 	predicates, idstrings, err := ingestorFunc(docTree)
@@ -98,7 +98,7 @@ func MergedIngest(
 	for _, d := range docs {
 		docTree, err := processorFunc(d)
 		if err != nil {
-			return fmt.Errorf("unable to process doc: %v, format: %v, document: %v", err, d.Format, d.Type)
+			return fmt.Errorf("unable to process doc: %v, format: %v, document: %v, source: %v", err, d.Format, d.Type, d.SourceInformation)
 		}
 
 		preds, idstrs, err := ingestorFunc(docTree)

--- a/pkg/ingestor/parser/common/helpers.go
+++ b/pkg/ingestor/parser/common/helpers.go
@@ -26,6 +26,11 @@ import (
 	"github.com/guacsec/guac/pkg/handler/processor"
 )
 
+type key string
+const (
+	KeyGraphqlEndpoint key = "graphqlEndpoint"
+)
+
 // TODO: change the DependencyType based on the relationship, currently set to unknown
 func GetIsDep(foundNode *model.PkgInputSpec, relatedPackNodes []*model.PkgInputSpec, relatedFileNodes []*model.PkgInputSpec, justification string, dependency model.DependencyType) (*assembler.IsDependencyIngest, error) {
 	if len(relatedFileNodes) > 0 {

--- a/pkg/ingestor/parser/csaf/parser_csaf_red_hat.go
+++ b/pkg/ingestor/parser/csaf/parser_csaf_red_hat.go
@@ -1,0 +1,183 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package csaf
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/guacsec/guac/internal/testing/ptrfrom"
+	"github.com/guacsec/guac/pkg/assembler"
+	"github.com/guacsec/guac/pkg/assembler/clients/generated"
+	assembler_helpers "github.com/guacsec/guac/pkg/assembler/clients/helpers"
+	"github.com/guacsec/guac/pkg/assembler/helpers"
+	"github.com/guacsec/guac/pkg/ingestor/parser/common"
+	"github.com/guacsec/guac/pkg/logging"
+	"golang.org/x/exp/maps"
+)
+
+type csafParserRedHat struct {
+	csafParser
+}
+
+func NewCsafRedHatParser() common.DocumentParser {
+	return &csafParserRedHat{
+		csafParser{
+			identifierStrings: &common.IdentifierStrings{},
+		},
+	}
+}
+
+// findPkgSpec finds the package specification for the product with the
+// given ID in the CSAF document. It returns a pointer to the package
+// specification if found, otherwise an error.
+func (c *csafParserRedHat) findPkgSpec(ctx context.Context, product_id string) (*generated.PkgInputSpec, error) {
+	logger := logging.FromContext(ctx)
+	pref, relToProdRef := findProductsRef(ctx, c.csaf.ProductTree, product_id)
+	if pref == nil {
+		return nil, fmt.Errorf("unable to locate product reference for id %s", product_id)
+	}
+
+	purl := findPurl(ctx, c.csaf.ProductTree, *pref)
+	if purl == nil {
+		return nil, fmt.Errorf("unable to locate product url for reference %s", *pref)
+	} else if *purl == "" {
+		// if no purl is available in the product reference entry, then let's try to search for it into guac
+		endpoint, ok := ctx.Value(common.KeyGraphqlEndpoint).(string)
+		if !ok {
+			return nil, fmt.Errorf("unable to locate product url for reference %s due to missing graphqlEndpoint value", *pref)
+		}
+		gqlclient, err := assembler_helpers.GetGqlClient(endpoint)
+		if err != nil {
+			return nil, err
+		}
+		// get all packages with metadata with key == "cpe"
+		filterHasMetadata := &generated.HasMetadataSpec{
+			Key: ptrfrom.String("cpe"),
+		}
+		cpe := findCPE(ctx, c.csaf.ProductTree, *relToProdRef)
+		pkgsWithMetadata, err := generated.HasMetadata(ctx, gqlclient, *filterHasMetadata)
+		if err != nil {
+			return nil, err
+		}
+		purlsMap := make(map[string]struct{})
+		var packageName, packageNamespace *string
+		packageInfo := strings.Split(*pref, "/")
+		if len(packageInfo) == 2 {
+			// pref "io.quarkus/quarkus-spring-security"
+			packageNamespace = &packageInfo[0]
+			packageName = &packageInfo[1]
+		} else if len(packageInfo) == 1 {
+			// pref "vim"
+			packageName = &packageInfo[0]
+		} else {
+			return nil, fmt.Errorf("unable to derive a valid package reference from %v", pref)
+		}
+		for _, pkgWithMetadata := range pkgsWithMetadata.HasMetadata {
+			// check the ones whose value starts with the CPE found in the VEX
+			if strings.HasPrefix(pkgWithMetadata.Value, *cpe) {
+				switch productPkg := pkgWithMetadata.Subject.(type) {
+				case *generated.AllHasMetadataSubjectPackage:
+					toPkg, err := helpers.PurlToPkgFilter(helpers.AllPkgTreeToPurl(&productPkg.AllPkgTree))
+					if err != nil {
+						logger.Warnf("Failed to handle the HasMetadata response %+v\n", productPkg)
+						continue
+					}
+					filterProductDependencies := &generated.HasSBOMSpec{
+						IncludedDependencies: []generated.IsDependencySpec{
+							{
+								Package: &toPkg,
+								DependencyPackage: &generated.PkgSpec{
+									Namespace: packageNamespace,
+									Name:      packageName,
+								},
+							},
+						},
+					}
+					includedDependenciesHasSBOMResponse, err := generated.HasSBOMs(ctx, gqlclient, *filterProductDependencies)
+					if err != nil {
+						return nil, err
+					}
+					for _, hasSBOM := range includedDependenciesHasSBOMResponse.HasSBOM {
+						for _, includedDependency := range hasSBOM.IncludedDependencies {
+							if strings.EqualFold(includedDependency.DependencyPackage.Namespaces[0].Names[0].Name, *packageName) {
+								vulnerablePkgInputSpec, err := helpers.PurlToPkg(helpers.AllPkgTreeToPurl(&includedDependency.DependencyPackage.AllPkgTree))
+								if err != nil {
+									logger.Warnf("Failed to handle the IsDependency response %+v\n", includedDependency)
+								} else {
+									purlsMap[helpers.PkgInputSpecToPurl(vulnerablePkgInputSpec)] = struct{}{}
+								}
+							}
+						}
+					}
+				case *generated.AllHasMetadataSubjectSource:
+					continue
+				case *generated.AllHasMetadataSubjectArtifact:
+					continue
+				}
+			}
+		}
+		purls := maps.Keys(purlsMap)
+		sort.Strings(purls)
+		if len(purls) > 0 {
+			if len(purls) > 1 {
+				logger.Warnf("More than one dependency package with name '%v' has been found for CPE %+v\n%v\n", *pref, *cpe, purls)
+			}
+			purl = &purls[0]
+			logger.Infof("[csaf] product_id '%v' mapped to guac package %v", product_id, *purl)
+		}
+	}
+
+	return helpers.PurlToPkg(*purl)
+}
+
+// GetPredicates generates the VEX and CertifyVuln predicates for the CSAF document.
+//
+// It returns a pointer to an assembler.IngestPredicates struct containing the
+// generated VEX and CertifyVuln predicates.
+func (c *csafParserRedHat) GetPredicates(ctx context.Context) *assembler.IngestPredicates {
+	logger := logging.FromContext(ctx)
+	rv := &assembler.IngestPredicates{}
+	var vis = make(map[string]assembler.VexIngest)
+
+	for _, v := range c.csaf.Vulnerabilities {
+		vuln, err := helpers.CreateVulnInput(v.CVE)
+		if err != nil {
+			return nil
+		}
+
+		statuses := []string{"fixed", "known_not_affected", "known_affected", "first_affected", "first_fixed", "last_affected", "recommended", "under_investigation"}
+		for _, status := range statuses {
+			products := v.ProductStatus[status]
+			for _, product := range products {
+				vi := generateVexIngest(ctx, &c.csafParser, c, vuln, &v, status, product)
+				if vi == nil {
+					continue
+				}
+				var purl = helpers.PkgInputSpecToPurl(vi.Pkg)
+				if _, ok := vis[purl]; ok {
+					logger.Debugf("Duplicate ingest entry %v\n", vis)
+				} else {
+					vis[purl] = *vi
+				}
+			}
+		}
+	}
+	rv.Vex = maps.Values(vis)
+	return rv
+}

--- a/pkg/ingestor/parser/parser.go
+++ b/pkg/ingestor/parser/parser.go
@@ -41,7 +41,10 @@ func init() {
 	_ = RegisterDocumentParser(cyclonedx.NewCycloneDXParser, processor.DocumentCycloneDX)
 	_ = RegisterDocumentParser(scorecard.NewScorecardParser, processor.DocumentScorecard)
 	_ = RegisterDocumentParser(deps_dev.NewDepsDevParser, processor.DocumentDepsDev)
-	_ = RegisterDocumentParser(csaf.NewCsafParser, processor.DocumentCsaf)
+	// TODO restore the NewCsafParser for DocumentCsaf once everything on the CSAF Red Hat parser will be done
+	//_ = RegisterDocumentParser(csaf.NewCsafParser, processor.DocumentCsaf)
+	_ = RegisterDocumentParser(csaf.NewCsafRedHatParser, processor.DocumentCsaf)
+	_ = RegisterDocumentParser(csaf.NewCsafRedHatParser, processor.DocumentCsafRedHat)
 	_ = RegisterDocumentParser(open_vex.NewOpenVEXParser, processor.DocumentOpenVEX)
 }
 


### PR DESCRIPTION
# Description of the PR

https://issues.redhat.com/browse/TC-1689

In ffe296b I've decided to start evaluating e2e tests again:

- `HasSBOM` and `Vulnerabilities` queries have been moved as the first tests in order to ensure everything has been ingested.

- `CVE_2023_1664` check has been added to verify `CertifyVEX` has been created for CVE-2023-1664 and package `keycloak-core` because this CVE is based upon the RH correlation, i.e. the ingestion's log reports
  ```
  [csaf] product_id 'red_hat_build_of_quarkus:org.keycloak/keycloak-core' mapped to guac package pkg:maven/org.keycloak/keycloak-core@18.0.6.redhat-00001?repository_url=https%3A%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=jar
  ```

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If GraphQL schema is changed, GraphQL client updates/additions have been made
- [ ] If OpenAPI spec is changed, `make generate` has been run
- [ ] If ent schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
