### PR TITLE
Add build job to test build works

### DIFF
--- a/.github/workflows/ci-trustification.yaml
+++ b/.github/workflows/ci-trustification.yaml
@@ -131,6 +131,25 @@ jobs:
 #      - name: Check that all linted text is up to date
 #        run: make generated_up_to_date
 
+  build:
+    runs-on: ubuntu-latest
+    name: CI for build
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # tag=v3
+      - name: setup-go
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # tag=v3.2.1
+        with:
+          go-version: '1.21'
+      - uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+      - name: Setup the project
+        run: go mod download
+      - name: Run tests
+        run: make build
+
   end-to-end:
     name: E2E Trustification
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-trustification.yaml
+++ b/.github/workflows/ci-trustification.yaml
@@ -133,7 +133,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    name: CI for build
+    name: GO generate/build
     steps:
       - name: Checkout code
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # tag=v3
@@ -147,8 +147,10 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
       - name: Setup the project
         run: go mod download
-      - name: Run tests
-        run: make build
+      - name: Run generate
+        run: go generate ./...
+      - name: Run build
+        run: go build ./...
 
   end-to-end:
     name: E2E Trustification

--- a/cmd/guacmigrate/cmd/migrate.go
+++ b/cmd/guacmigrate/cmd/migrate.go
@@ -25,7 +25,6 @@ import (
 	"github.com/guacsec/guac/pkg/assembler/backends"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/backend"
 	entbackend "github.com/guacsec/guac/pkg/assembler/backends/ent/backend"
-	_ "github.com/guacsec/guac/pkg/assembler/backends/inmem"
 	"github.com/guacsec/guac/pkg/logging"
 	"github.com/spf13/cobra"
 )


### PR DESCRIPTION
# Description of the PR

Recent PR broken the `make build` command and I've figured out there's no CI job to check the build works so I'm adding it.

Right now it should fail with an error on the package `github.com/guacsec/guac/pkg/assembler/backends/inmem` import in  `cmd/guacmigrate/cmd/migrate.go:28:2`.

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
