### PR TITLE
fix: disable arm build explicitly

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -172,7 +172,6 @@ builds:
     goarch:
       - amd64
       - arm64
-      - arm
     ignore:
       - goos: windows
         goarch: arm64


### PR DESCRIPTION
# Description of the PR

Backport:

- https://github.com/trustification/guac/commit/847e04ca66570c1a58c23708800de7864bfb3ae5

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
