### PR TITLE
TC-1802 Fix CertifyLegal ingestion queries

### DIFF
--- a/demo/graphql/queries-trustification.gql
+++ b/demo/graphql/queries-trustification.gql
@@ -415,3 +415,12 @@ query TC_1609_HasSBOM {
     ...allHasSBOMTree
   }
 }
+
+query TC_1802_HasSBOM {
+  HasSBOM (hasSBOMSpec:{uri: "https://access.redhat.com/security/data/sbom/spdx/RHEL-9.4.0.Z.MAIN+EUS"}) {
+    uri
+    algorithm
+    id
+    digest
+  }
+}

--- a/internal/testing/e2e-trustification/e2e
+++ b/internal/testing/e2e-trustification/e2e
@@ -124,4 +124,12 @@ echo @@@@ Running TC-1689 queries and validating output
 cat "$queries" | gql-cli http://localhost:8080/query -o TC_1609_HasSBOM | jq --sort-keys 'del(.. | .id?) | del(.. | .downloadLocation?) | del(.. | .origin?) | .HasSBOM[] ' > "${GUAC_DIR}/gotTC_1689_HasSBOM.json"
 diff -u "${SCRIPT_DIR}/expectTC_1689_HasSBOM.json" "${GUAC_DIR}/gotTC_1689_HasSBOM.json"
 
+echo @@@@ Ingesting TC-1802-rhel-9.4.0.json.bz2 into server
+time go run ./cmd/guacone collect files ${GUAC_DIR}/internal/testing/testdata/exampledata/TC-1802-rhel-9.4.0.json.bz2;
+
+echo @@@@ Running TC-1802 queries and validating output
+
+cat "$queries" | gql-cli http://localhost:8080/query -o TC_1802_HasSBOM | jq --sort-keys 'del(.. | .id?) | del(.. | .downloadLocation?) | del(.. | .origin?) | .HasSBOM[] ' > "${GUAC_DIR}/gotTC_1802_HasSBOM.json"
+diff -u "${SCRIPT_DIR}/expectTC_1802_HasSBOM.json" "${GUAC_DIR}/gotTC_1802_HasSBOM.json"
+
 # Note: graphql_playground is left running, CI will clean it up

--- a/internal/testing/e2e-trustification/expectTC_1802_HasSBOM.json
+++ b/internal/testing/e2e-trustification/expectTC_1802_HasSBOM.json
@@ -1,0 +1,5 @@
+{
+  "algorithm": "sha256",
+  "digest": "c262a33d1516e0db38634c8acb5ea3de8a7c4a74296922ac52811979014e486c",
+  "uri": "https://access.redhat.com/security/data/sbom/spdx/RHEL-9.4.0.Z.MAIN+EUS"
+}

--- a/pkg/assembler/backends/ent/backend/certifyLegal.go
+++ b/pkg/assembler/backends/ent/backend/certifyLegal.go
@@ -138,8 +138,6 @@ func (b *EntBackend) IngestCertifyLegals(ctx context.Context, subjects model.Pac
 func certifyLegalConflictColumns() []string {
 	return []string{
 		certifylegal.FieldDeclaredLicense,
-		certifylegal.FieldDiscoveredLicense,
-		certifylegal.FieldAttribution,
 		certifylegal.FieldJustification,
 		certifylegal.FieldTimeScanned,
 		certifylegal.FieldOrigin,

--- a/pkg/assembler/backends/ent/migrate/schema.go
+++ b/pkg/assembler/backends/ent/migrate/schema.go
@@ -219,17 +219,25 @@ var (
 		},
 		Indexes: []*schema.Index{
 			{
-				Name:    "certifylegal_source_id_declared_license_discovered_license_attribution_justification_time_scanned_origin_collector_document_ref_declared_licenses_hash_discovered_licenses_hash",
+				Name:    "certifylegal_source_id_declared_license_justification_time_scanned_origin_collector_document_ref_declared_licenses_hash_discovered_licenses_hash",
 				Unique:  true,
-				Columns: []*schema.Column{CertifyLegalsColumns[12], CertifyLegalsColumns[1], CertifyLegalsColumns[2], CertifyLegalsColumns[3], CertifyLegalsColumns[4], CertifyLegalsColumns[5], CertifyLegalsColumns[6], CertifyLegalsColumns[7], CertifyLegalsColumns[8], CertifyLegalsColumns[9], CertifyLegalsColumns[10]},
+				Columns: []*schema.Column{CertifyLegalsColumns[12], CertifyLegalsColumns[1], CertifyLegalsColumns[4], CertifyLegalsColumns[5], CertifyLegalsColumns[6], CertifyLegalsColumns[7], CertifyLegalsColumns[8], CertifyLegalsColumns[9], CertifyLegalsColumns[10]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "package_id IS NULL AND source_id IS NOT NULL",
 				},
 			},
 			{
-				Name:    "certifylegal_package_id_declared_license_discovered_license_attribution_justification_time_scanned_origin_collector_document_ref_declared_licenses_hash_discovered_licenses_hash",
+				Name:    "certifylegal_package_id_declared_license_justification_time_scanned_origin_collector_document_ref_declared_licenses_hash_discovered_licenses_hash",
 				Unique:  true,
-				Columns: []*schema.Column{CertifyLegalsColumns[11], CertifyLegalsColumns[1], CertifyLegalsColumns[2], CertifyLegalsColumns[3], CertifyLegalsColumns[4], CertifyLegalsColumns[5], CertifyLegalsColumns[6], CertifyLegalsColumns[7], CertifyLegalsColumns[8], CertifyLegalsColumns[9], CertifyLegalsColumns[10]},
+				Columns: []*schema.Column{CertifyLegalsColumns[11], CertifyLegalsColumns[1], CertifyLegalsColumns[4], CertifyLegalsColumns[5], CertifyLegalsColumns[6], CertifyLegalsColumns[7], CertifyLegalsColumns[8], CertifyLegalsColumns[9], CertifyLegalsColumns[10]},
+				Annotation: &entsql.IndexAnnotation{
+					Where: "package_id IS NOT NULL AND source_id IS NULL",
+				},
+			},
+			{
+				Name:    "certifylegal_package_id",
+				Unique:  false,
+				Columns: []*schema.Column{CertifyLegalsColumns[11]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "package_id IS NOT NULL AND source_id IS NULL",
 				},

--- a/pkg/assembler/backends/ent/schema/certifylegal.go
+++ b/pkg/assembler/backends/ent/schema/certifylegal.go
@@ -63,13 +63,14 @@ func (CertifyLegal) Edges() []ent.Edge {
 
 func (CertifyLegal) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("source_id", "declared_license", "discovered_license", "attribution", "justification", "time_scanned",
+		index.Fields("source_id", "declared_license", "justification", "time_scanned",
 			"origin", "collector", "document_ref", "declared_licenses_hash", "discovered_licenses_hash").
 			Unique().
 			Annotations(entsql.IndexWhere("package_id IS NULL AND source_id IS NOT NULL")),
-		index.Fields("package_id", "declared_license", "discovered_license", "attribution", "justification", "time_scanned",
+		index.Fields("package_id", "declared_license", "justification", "time_scanned",
 			"origin", "collector", "document_ref", "declared_licenses_hash", "discovered_licenses_hash").
 			Unique().
 			Annotations(entsql.IndexWhere("package_id IS NOT NULL AND source_id IS NULL")),
+		index.Fields("package_id").Annotations(entsql.IndexWhere("package_id IS NOT NULL AND source_id IS NULL")), // query when subject is package ID
 	}
 }


### PR DESCRIPTION
# Description of the PR

https://issues.redhat.com/browse/TC-1802

Backports changes to `pkg/assembler/backends/ent/schema/certifylegal.go` and `pkg/assembler/backends/ent/backend/certifyLegal.go` from newer versions:

- https://github.com/guacsec/guac/pull/2139
- https://github.com/guacsec/guac/pull/2088
- https://github.com/guacsec/guac/pull/2032

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
