### PR TITLE
[trustification-v0.7.2] TC-1757 Fix SPDX SBOM ingestion with multiple purls in externalRefs array 

### DIFF
--- a/demo/graphql/queries-trustification.gql
+++ b/demo/graphql/queries-trustification.gql
@@ -424,3 +424,27 @@ query TC_1802_HasSBOM {
     digest
   }
 }
+
+query TC_1757_Package_x86_64 {
+  packages (pkgSpec:{
+    name:"openssl",
+    qualifiers: [
+      {key:"arch", value:"src"},
+      {key:"repository_id", value:"rhel-9-for-x86_64-baseos-eus-source-rpms"}
+    ]
+  }) {
+    ...allPkgTree
+  }
+}
+
+query TC_1757_Package_aarch64 {
+  packages (pkgSpec:{
+    name:"openssl",
+    qualifiers: [
+      {key:"arch", value:"src"},
+      {key:"repository_id", value:"rhel-9-for-aarch64-baseos-eus-source-rpms"}
+    ]
+  }) {
+    ...allPkgTree
+  }
+}

--- a/internal/testing/e2e-trustification/e2e
+++ b/internal/testing/e2e-trustification/e2e
@@ -116,6 +116,17 @@ echo @@@@ Running TC_1609 queries and validating output
 cat "$queries" | gql-cli http://localhost:8080/query -o TC_1609_FindDependentProduct | jq 'del(.. | .id?) | del(.. | .downloadLocation?) | del(.. | .origin?) | .findDependentProduct[].subject.namespaces[]?.names[]?.versions[]?.qualifiers? |= sort | .findDependentProduct' > "${GUAC_DIR}/gotTC_1609_FindDependentProduct.json"
 diff -u "${SCRIPT_DIR}/expectTC_1609_FindDependentProduct.json" "${GUAC_DIR}/gotTC_1609_FindDependentProduct.json"
 
+echo @@@@ Ingesting TC_1757_openssl-3.0.7-18.el9_2.spdx.json into server
+time go run ./cmd/guacone collect files ${GUAC_DIR}/internal/testing/testdata/exampledata/TC_1757_openssl-3.0.7-18.el9_2.spdx.json;
+
+echo @@@@ Running TC_1757 queries and validating output
+
+cat "$queries" | gql-cli http://localhost:8080/query -o TC_1757_Package_x86_64 | jq 'del(.. | .id?) | .packages[].namespaces[]?.names[]?.versions[]?.qualifiers? |= sort | .packages ' > "${GUAC_DIR}/gotTC_1757_Package_x86_64.json"
+diff -u "${SCRIPT_DIR}/expectTC_1757_Package_x86_64.json" "${GUAC_DIR}/gotTC_1757_Package_x86_64.json"
+
+cat "$queries" | gql-cli http://localhost:8080/query -o TC_1757_Package_aarch64 | jq 'del(.. | .id?) | .packages[].namespaces[]?.names[]?.versions[]?.qualifiers? |= sort | .packages ' > "${GUAC_DIR}/gotTC_1757_Package_aarch64.json"
+diff -u "${SCRIPT_DIR}/expectTC_1757_Package_aarch64.json" "${GUAC_DIR}/gotTC_1757_Package_aarch64.json"
+
 echo @@@@ Ingesting TC-1689-spdx-rpmmod.json into server
 time go run ./cmd/guacone collect files ${GUAC_DIR}/internal/testing/testdata/exampledata/TC-1689-spdx-rpmmod.json;
 

--- a/internal/testing/e2e-trustification/expectTC_1757_Package_aarch64.json
+++ b/internal/testing/e2e-trustification/expectTC_1757_Package_aarch64.json
@@ -1,0 +1,31 @@
+[
+  {
+    "type": "rpm",
+    "namespaces": [
+      {
+        "namespace": "redhat",
+        "names": [
+          {
+            "name": "openssl",
+            "versions": [
+              {
+                "version": "3.0.7-18.el9_2",
+                "qualifiers": [
+                  {
+                    "key": "arch",
+                    "value": "src"
+                  },
+                  {
+                    "key": "repository_id",
+                    "value": "rhel-9-for-aarch64-baseos-eus-source-rpms"
+                  }
+                ],
+                "subpath": ""
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/internal/testing/e2e-trustification/expectTC_1757_Package_x86_64.json
+++ b/internal/testing/e2e-trustification/expectTC_1757_Package_x86_64.json
@@ -1,0 +1,31 @@
+[
+  {
+    "type": "rpm",
+    "namespaces": [
+      {
+        "namespace": "redhat",
+        "names": [
+          {
+            "name": "openssl",
+            "versions": [
+              {
+                "version": "3.0.7-18.el9_2",
+                "qualifiers": [
+                  {
+                    "key": "arch",
+                    "value": "src"
+                  },
+                  {
+                    "key": "repository_id",
+                    "value": "rhel-9-for-x86_64-baseos-eus-source-rpms"
+                  }
+                ],
+                "subpath": ""
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/internal/testing/testdata/exampledata/TC_1757_openssl-3.0.7-18.el9_2.spdx.json
+++ b/internal/testing/testdata/exampledata/TC_1757_openssl-3.0.7-18.el9_2.spdx.json
@@ -1,0 +1,1460 @@
+{
+  "spdxVersion": "SPDX-2.3",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "creationInfo": {
+    "created": "2006-08-14T02:34:56-06:00",
+    "creators": [
+      "Tool: example SPDX document only"
+    ]
+  },
+  "name": "openssl-3.0.7-18.el9_2",
+  "documentNamespace": "https://www.redhat.com/openssl-3.0.7-18.el9_2.spdx.json",
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-SRPM",
+      "name": "openssl",
+      "versionInfo": "3.0.7-18.el9_2",
+      "supplier": "Organization: Red Hat",
+      "downloadLocation": "NOASSERTION",
+      "packageFileName": "openssl-3.0.7-18.el9_2.src.rpm",
+      "licenseConcluded": "Apache-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=src&repository_id=rhel-9-for-x86_64-baseos-eus-source-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=src&repository_id=rhel-9-for-ppc64le-baseos-eus-source-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=src&repository_id=rhel-9-for-s390x-baseos-eus-source-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=src&repository_id=rhel-9-for-aarch64-baseos-eus-source-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=src&repository_id=rhel-9-for-i686-baseos-eus-source-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=src&repository_id=rhel-9-for-x86_64-baseos-aus-source-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=src&repository_id=rhel-9-for-ppc64le-baseos-aus-source-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=src&repository_id=rhel-9-for-s390x-baseos-aus-source-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=src&repository_id=rhel-9-for-aarch64-baseos-aus-source-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=src&repository_id=rhel-9-for-i686-baseos-aus-source-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=src&repository_id=rhel-9-for-x86_64-baseos-e4s-source-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=src&repository_id=rhel-9-for-ppc64le-baseos-e4s-source-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=src&repository_id=rhel-9-for-s390x-baseos-e4s-source-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=src&repository_id=rhel-9-for-aarch64-baseos-e4s-source-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=src&repository_id=rhel-9-for-i686-baseos-e4s-source-rpms"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "31b5079268339cff7ba65a0aee77930560c5adef4b1b3f8f5927a43ee46a56d9"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-Source0-origin",
+      "name": "openssl",
+      "versionInfo": "3.0.7",
+      "downloadLocation": "https://openssl.org/source/openssl-3.0.7.tar.gz",
+      "packageFileName": "openssl-3.0.7.tar.gz",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "83049d042a260e696f62406ac5c08bf706fd84383f945cf21bd61e9ed95c396e"
+        }
+      ],
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:generic/openssl@3.0.7?download_url=https://openssl.org/source/openssl-3.0.7.tar.gz&checksum=sha256:83049d042a260e696f62406ac5c08bf706fd84383f945cf21bd61e9ed95c396e"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-Source0",
+      "name": "openssl",
+      "versionInfo": "3.0.7",
+      "downloadLocation": "https://github.com/(RH openssl midstream repo)/archive/refs/tags/3.0.7.tar.gz",
+      "packageFileName": "openssl-3.0.7-hobbled.tar.gz",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4105046836812ed422922f851a57500118a99cc0f009b7eff2b3436110393377"
+        }
+      ],
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:generic/openssl@3.0.7?download_url=https://github.com/(RH openssl midstream repo)/archive/refs/tags/3.0.7.tar.gz"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-aarch64-openssl-perl",
+      "name": "openssl-perl",
+      "versionInfo": "3.0.7-18.el9_2",
+      "supplier": "Organization: Red Hat",
+      "downloadLocation": "NOASSERTION",
+      "packageFileName": "openssl-perl-3.0.7-18.el9_2.aarch64.rpm",
+      "licenseConcluded": "Apache-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-perl@3.0.7-18.el9_2?arch=aarch64&repository_id=rhel-9-for-aarch64-baseos-eus-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-perl@3.0.7-18.el9_2?arch=aarch64&repository_id=rhel-9-for-aarch64-baseos-aus-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-perl@3.0.7-18.el9_2?arch=aarch64&repository_id=rhel-9-for-aarch64-baseos-e4s-rpms"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "96e53b2da90ce5ad109ba659ce3ed1b5a819b108c95fc493f84847429898b2ed"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-aarch64-openssl-debuginfo",
+      "name": "openssl-debuginfo",
+      "versionInfo": "3.0.7-18.el9_2",
+      "supplier": "Organization: Red Hat",
+      "downloadLocation": "NOASSERTION",
+      "packageFileName": "openssl-debuginfo-3.0.7-18.el9_2.aarch64.rpm",
+      "licenseConcluded": "Apache-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-debuginfo@3.0.7-18.el9_2?arch=aarch64&repository_id=rhel-9-for-aarch64-baseos-eus-debug-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-debuginfo@3.0.7-18.el9_2?arch=aarch64&repository_id=rhel-9-for-aarch64-baseos-aus-debug-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-debuginfo@3.0.7-18.el9_2?arch=aarch64&repository_id=rhel-9-for-aarch64-baseos-e4s-debug-rpms"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "8721bc9673ccc43f729485aba48fd75a927305980f48ee9d0b79d06937b68d16"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-aarch64-openssl-libs",
+      "name": "openssl-libs",
+      "versionInfo": "3.0.7-18.el9_2",
+      "supplier": "Organization: Red Hat",
+      "downloadLocation": "NOASSERTION",
+      "packageFileName": "openssl-libs-3.0.7-18.el9_2.aarch64.rpm",
+      "licenseConcluded": "Apache-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-libs@3.0.7-18.el9_2?arch=aarch64&repository_id=rhel-9-for-aarch64-baseos-eus-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-libs@3.0.7-18.el9_2?arch=aarch64&repository_id=rhel-9-for-aarch64-baseos-aus-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-libs@3.0.7-18.el9_2?arch=aarch64&repository_id=rhel-9-for-aarch64-baseos-e4s-rpms"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "cae5941219fd64e75c2b29509c6fe712bef77181a586702275a46a5e812d4dd4"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-aarch64-openssl-libs-debuginfo",
+      "name": "openssl-libs-debuginfo",
+      "versionInfo": "3.0.7-18.el9_2",
+      "supplier": "Organization: Red Hat",
+      "downloadLocation": "NOASSERTION",
+      "packageFileName": "openssl-libs-debuginfo-3.0.7-18.el9_2.aarch64.rpm",
+      "licenseConcluded": "Apache-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-libs-debuginfo@3.0.7-18.el9_2?arch=aarch64&repository_id=rhel-9-for-aarch64-baseos-eus-debug-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-libs-debuginfo@3.0.7-18.el9_2?arch=aarch64&repository_id=rhel-9-for-aarch64-baseos-aus-debug-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-libs-debuginfo@3.0.7-18.el9_2?arch=aarch64&repository_id=rhel-9-for-aarch64-baseos-e4s-debug-rpms"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "036985b5bd34712963e4a9009dd196e4f583479283d88b6e908a231aa5bddfae"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-aarch64-openssl",
+      "name": "openssl",
+      "versionInfo": "3.0.7-18.el9_2",
+      "supplier": "Organization: Red Hat",
+      "downloadLocation": "NOASSERTION",
+      "packageFileName": "openssl-3.0.7-18.el9_2.aarch64.rpm",
+      "licenseConcluded": "Apache-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=aarch64&repository_id=rhel-9-for-aarch64-baseos-eus-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=aarch64&repository_id=rhel-9-for-aarch64-baseos-aus-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=aarch64&repository_id=rhel-9-for-aarch64-baseos-e4s-rpms"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "aaafa61c115ec37bb3895e124216ce46774069e49f6178248df085708ecb3878"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-aarch64-openssl-debugsource",
+      "name": "openssl-debugsource",
+      "versionInfo": "3.0.7-18.el9_2",
+      "supplier": "Organization: Red Hat",
+      "downloadLocation": "NOASSERTION",
+      "packageFileName": "openssl-debugsource-3.0.7-18.el9_2.aarch64.rpm",
+      "licenseConcluded": "Apache-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-debugsource@3.0.7-18.el9_2?arch=aarch64&repository_id=rhel-9-for-aarch64-baseos-eus-source-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-debugsource@3.0.7-18.el9_2?arch=aarch64&repository_id=rhel-9-for-aarch64-baseos-aus-source-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-debugsource@3.0.7-18.el9_2?arch=aarch64&repository_id=rhel-9-for-aarch64-baseos-e4s-source-rpms"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "036bd68632078d2b12e87f4541047823b5675d7e1141e56639cbc1e2e42c9f65"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-aarch64-openssl-devel",
+      "name": "openssl-devel",
+      "versionInfo": "3.0.7-18.el9_2",
+      "supplier": "Organization: Red Hat",
+      "downloadLocation": "NOASSERTION",
+      "packageFileName": "openssl-devel-3.0.7-18.el9_2.aarch64.rpm",
+      "licenseConcluded": "Apache-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-devel@3.0.7-18.el9_2?arch=aarch64&repository_id=rhel-9-for-aarch64-baseos-eus-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-devel@3.0.7-18.el9_2?arch=aarch64&repository_id=rhel-9-for-aarch64-baseos-aus-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-devel@3.0.7-18.el9_2?arch=aarch64&repository_id=rhel-9-for-aarch64-baseos-e4s-rpms"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "deff41d222f613c3292d1bd0256c793c7fc7d5a4d61a24fa81f23990123bd79d"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-ppc64le-openssl-perl",
+      "name": "openssl-perl",
+      "versionInfo": "3.0.7-18.el9_2",
+      "supplier": "Organization: Red Hat",
+      "downloadLocation": "NOASSERTION",
+      "packageFileName": "openssl-perl-3.0.7-18.el9_2.ppc64le.rpm",
+      "licenseConcluded": "Apache-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-perl@3.0.7-18.el9_2?arch=ppc64le&repository_id=rhel-9-for-ppc64le-baseos-eus-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-perl@3.0.7-18.el9_2?arch=ppc64le&repository_id=rhel-9-for-ppc64le-baseos-aus-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-perl@3.0.7-18.el9_2?arch=ppc64le&repository_id=rhel-9-for-ppc64le-baseos-e4s-rpms"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "7ae23594204f2688d5b16be98782d5456080f55e6baf76172d8cb4e100c2507e"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-ppc64le-openssl-libs",
+      "name": "openssl-libs",
+      "versionInfo": "3.0.7-18.el9_2",
+      "supplier": "Organization: Red Hat",
+      "downloadLocation": "NOASSERTION",
+      "packageFileName": "openssl-libs-3.0.7-18.el9_2.ppc64le.rpm",
+      "licenseConcluded": "Apache-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-libs@3.0.7-18.el9_2?arch=ppc64le&repository_id=rhel-9-for-ppc64le-baseos-eus-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-libs@3.0.7-18.el9_2?arch=ppc64le&repository_id=rhel-9-for-ppc64le-baseos-aus-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-libs@3.0.7-18.el9_2?arch=ppc64le&repository_id=rhel-9-for-ppc64le-baseos-e4s-rpms"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "6c35abfc44cc24048921fd519bbcdba0bc43cf45cdece57df99ede720600a686"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-ppc64le-openssl-devel",
+      "name": "openssl-devel",
+      "versionInfo": "3.0.7-18.el9_2",
+      "supplier": "Organization: Red Hat",
+      "downloadLocation": "NOASSERTION",
+      "packageFileName": "openssl-devel-3.0.7-18.el9_2.ppc64le.rpm",
+      "licenseConcluded": "Apache-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-devel@3.0.7-18.el9_2?arch=ppc64le&repository_id=rhel-9-for-ppc64le-baseos-eus-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-devel@3.0.7-18.el9_2?arch=ppc64le&repository_id=rhel-9-for-ppc64le-baseos-aus-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-devel@3.0.7-18.el9_2?arch=ppc64le&repository_id=rhel-9-for-ppc64le-baseos-e4s-rpms"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "b2e00a6e064e8efd9fac7b4633221ef5b3f49fb16e6eb2752cffae6965007cb7"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-ppc64le-openssl",
+      "name": "openssl",
+      "versionInfo": "3.0.7-18.el9_2",
+      "supplier": "Organization: Red Hat",
+      "downloadLocation": "NOASSERTION",
+      "packageFileName": "openssl-3.0.7-18.el9_2.ppc64le.rpm",
+      "licenseConcluded": "Apache-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=ppc64le&repository_id=rhel-9-for-ppc64le-baseos-eus-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=ppc64le&repository_id=rhel-9-for-ppc64le-baseos-aus-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=ppc64le&repository_id=rhel-9-for-ppc64le-baseos-e4s-rpms"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "10135a468b85a35b0373609ad48c50e71499d034c6f7e7455691b63f87105f12"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-ppc64le-openssl-debuginfo",
+      "name": "openssl-debuginfo",
+      "versionInfo": "3.0.7-18.el9_2",
+      "supplier": "Organization: Red Hat",
+      "downloadLocation": "NOASSERTION",
+      "packageFileName": "openssl-debuginfo-3.0.7-18.el9_2.ppc64le.rpm",
+      "licenseConcluded": "Apache-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-debuginfo@3.0.7-18.el9_2?arch=ppc64le&repository_id=rhel-9-for-ppc64le-baseos-eus-debug-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-debuginfo@3.0.7-18.el9_2?arch=ppc64le&repository_id=rhel-9-for-ppc64le-baseos-aus-debug-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-debuginfo@3.0.7-18.el9_2?arch=ppc64le&repository_id=rhel-9-for-ppc64le-baseos-e4s-debug-rpms"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "8e14cfaf5ae8bf1858b8d262b6d891dfdcc31378b6805345b8c1e08e4f0ce442"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-ppc64le-openssl-debugsource",
+      "name": "openssl-debugsource",
+      "versionInfo": "3.0.7-18.el9_2",
+      "supplier": "Organization: Red Hat",
+      "downloadLocation": "NOASSERTION",
+      "packageFileName": "openssl-debugsource-3.0.7-18.el9_2.ppc64le.rpm",
+      "licenseConcluded": "Apache-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-debugsource@3.0.7-18.el9_2?arch=ppc64le&repository_id=rhel-9-for-ppc64le-baseos-eus-source-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-debugsource@3.0.7-18.el9_2?arch=ppc64le&repository_id=rhel-9-for-ppc64le-baseos-aus-source-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-debugsource@3.0.7-18.el9_2?arch=ppc64le&repository_id=rhel-9-for-ppc64le-baseos-e4s-source-rpms"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d7de194a98e577ebaa0344c55002f83c2d22b52bf62cac22920759f2679e8124"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-ppc64le-openssl-libs-debuginfo",
+      "name": "openssl-libs-debuginfo",
+      "versionInfo": "3.0.7-18.el9_2",
+      "supplier": "Organization: Red Hat",
+      "downloadLocation": "NOASSERTION",
+      "packageFileName": "openssl-libs-debuginfo-3.0.7-18.el9_2.ppc64le.rpm",
+      "licenseConcluded": "Apache-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-libs-debuginfo@3.0.7-18.el9_2?arch=ppc64le&repository_id=rhel-9-for-ppc64le-baseos-eus-debug-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-libs-debuginfo@3.0.7-18.el9_2?arch=ppc64le&repository_id=rhel-9-for-ppc64le-baseos-aus-debug-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-libs-debuginfo@3.0.7-18.el9_2?arch=ppc64le&repository_id=rhel-9-for-ppc64le-baseos-e4s-debug-rpms"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d6c29685fcd8a62504e223fcd4b520819118456cc65273e43c5fed19dd1d1a11"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-i686-openssl-libs-debuginfo",
+      "name": "openssl-libs-debuginfo",
+      "versionInfo": "3.0.7-18.el9_2",
+      "supplier": "Organization: Red Hat",
+      "downloadLocation": "NOASSERTION",
+      "packageFileName": "openssl-libs-debuginfo-3.0.7-18.el9_2.i686.rpm",
+      "licenseConcluded": "Apache-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-libs-debuginfo@3.0.7-18.el9_2?arch=i686&repository_id=rhel-9-for-i686-baseos-eus-debug-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-libs-debuginfo@3.0.7-18.el9_2?arch=i686&repository_id=rhel-9-for-i686-baseos-aus-debug-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-libs-debuginfo@3.0.7-18.el9_2?arch=i686&repository_id=rhel-9-for-i686-baseos-e4s-debug-rpms"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "8897777ff03ce9308b8e7dd890e3c22c3b9f0da29d641d3844a52635ed926649"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-i686-openssl-libs",
+      "name": "openssl-libs",
+      "versionInfo": "3.0.7-18.el9_2",
+      "supplier": "Organization: Red Hat",
+      "downloadLocation": "NOASSERTION",
+      "packageFileName": "openssl-libs-3.0.7-18.el9_2.i686.rpm",
+      "licenseConcluded": "Apache-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-libs@3.0.7-18.el9_2?arch=i686&repository_id=rhel-9-for-i686-baseos-eus-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-libs@3.0.7-18.el9_2?arch=i686&repository_id=rhel-9-for-i686-baseos-aus-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-libs@3.0.7-18.el9_2?arch=i686&repository_id=rhel-9-for-i686-baseos-e4s-rpms"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "ed85dfebb27dadf0d786da2aa15ce0dfbcb442ed38846360a82ab6abf7b71334"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-i686-openssl-debugsource",
+      "name": "openssl-debugsource",
+      "versionInfo": "3.0.7-18.el9_2",
+      "supplier": "Organization: Red Hat",
+      "downloadLocation": "NOASSERTION",
+      "packageFileName": "openssl-debugsource-3.0.7-18.el9_2.i686.rpm",
+      "licenseConcluded": "Apache-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-debugsource@3.0.7-18.el9_2?arch=i686&repository_id=rhel-9-for-i686-baseos-eus-source-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-debugsource@3.0.7-18.el9_2?arch=i686&repository_id=rhel-9-for-i686-baseos-aus-source-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-debugsource@3.0.7-18.el9_2?arch=i686&repository_id=rhel-9-for-i686-baseos-e4s-source-rpms"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d13f9f85d90d4d0e4f39bdc743f42dc064a6ca16e2cb85fe1695e8a08b9163b4"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-i686-openssl-devel",
+      "name": "openssl-devel",
+      "versionInfo": "3.0.7-18.el9_2",
+      "supplier": "Organization: Red Hat",
+      "downloadLocation": "NOASSERTION",
+      "packageFileName": "openssl-devel-3.0.7-18.el9_2.i686.rpm",
+      "licenseConcluded": "Apache-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-devel@3.0.7-18.el9_2?arch=i686&repository_id=rhel-9-for-i686-baseos-eus-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-devel@3.0.7-18.el9_2?arch=i686&repository_id=rhel-9-for-i686-baseos-aus-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-devel@3.0.7-18.el9_2?arch=i686&repository_id=rhel-9-for-i686-baseos-e4s-rpms"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "03d6054aafea54f4496f8c35550eec87f2ceb06566e3fd5eea0446bd91e3242e"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-i686-openssl-debuginfo",
+      "name": "openssl-debuginfo",
+      "versionInfo": "3.0.7-18.el9_2",
+      "supplier": "Organization: Red Hat",
+      "downloadLocation": "NOASSERTION",
+      "packageFileName": "openssl-debuginfo-3.0.7-18.el9_2.i686.rpm",
+      "licenseConcluded": "Apache-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-debuginfo@3.0.7-18.el9_2?arch=i686&repository_id=rhel-9-for-i686-baseos-eus-debug-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-debuginfo@3.0.7-18.el9_2?arch=i686&repository_id=rhel-9-for-i686-baseos-aus-debug-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-debuginfo@3.0.7-18.el9_2?arch=i686&repository_id=rhel-9-for-i686-baseos-e4s-debug-rpms"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "02867d6b799b5ebc56f1f945a474f59c6b1a8430da4acf3fa35dae9cf992ea58"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-i686-openssl",
+      "name": "openssl",
+      "versionInfo": "3.0.7-18.el9_2",
+      "supplier": "Organization: Red Hat",
+      "downloadLocation": "NOASSERTION",
+      "packageFileName": "openssl-3.0.7-18.el9_2.i686.rpm",
+      "licenseConcluded": "Apache-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=i686&repository_id=rhel-9-for-i686-baseos-eus-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=i686&repository_id=rhel-9-for-i686-baseos-aus-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=i686&repository_id=rhel-9-for-i686-baseos-e4s-rpms"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "b7b39d8d7a960d75da6347206927e5a9bf33642148a0d291b0205f70eac8bf42"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-i686-openssl-perl",
+      "name": "openssl-perl",
+      "versionInfo": "3.0.7-18.el9_2",
+      "supplier": "Organization: Red Hat",
+      "downloadLocation": "NOASSERTION",
+      "packageFileName": "openssl-perl-3.0.7-18.el9_2.i686.rpm",
+      "licenseConcluded": "Apache-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-perl@3.0.7-18.el9_2?arch=i686&repository_id=rhel-9-for-i686-baseos-eus-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-perl@3.0.7-18.el9_2?arch=i686&repository_id=rhel-9-for-i686-baseos-aus-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-perl@3.0.7-18.el9_2?arch=i686&repository_id=rhel-9-for-i686-baseos-e4s-rpms"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "d4732a4e60c831e1e8e4ddb89419a029accf2ee6dc1c2efe62e8bf20e97e2577"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-x86_64-openssl-libs-debuginfo",
+      "name": "openssl-libs-debuginfo",
+      "versionInfo": "3.0.7-18.el9_2",
+      "supplier": "Organization: Red Hat",
+      "downloadLocation": "NOASSERTION",
+      "packageFileName": "openssl-libs-debuginfo-3.0.7-18.el9_2.x86_64.rpm",
+      "licenseConcluded": "Apache-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-libs-debuginfo@3.0.7-18.el9_2?arch=x86_64&repository_id=rhel-9-for-x86_64-baseos-eus-debug-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-libs-debuginfo@3.0.7-18.el9_2?arch=x86_64&repository_id=rhel-9-for-x86_64-baseos-aus-debug-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-libs-debuginfo@3.0.7-18.el9_2?arch=x86_64&repository_id=rhel-9-for-x86_64-baseos-e4s-debug-rpms"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "596206f99a50ede734b1f989977b210289debcfdd972666bd0d5ba03e7afbf19"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-x86_64-openssl-debuginfo",
+      "name": "openssl-debuginfo",
+      "versionInfo": "3.0.7-18.el9_2",
+      "supplier": "Organization: Red Hat",
+      "downloadLocation": "NOASSERTION",
+      "packageFileName": "openssl-debuginfo-3.0.7-18.el9_2.x86_64.rpm",
+      "licenseConcluded": "Apache-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-debuginfo@3.0.7-18.el9_2?arch=x86_64&repository_id=rhel-9-for-x86_64-baseos-eus-debug-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-debuginfo@3.0.7-18.el9_2?arch=x86_64&repository_id=rhel-9-for-x86_64-baseos-aus-debug-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-debuginfo@3.0.7-18.el9_2?arch=x86_64&repository_id=rhel-9-for-x86_64-baseos-e4s-debug-rpms"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "7fbdc911663e437e7be7e30f5bd87450f4ff38551ecbb3de27e362bb9f2ac2aa"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-x86_64-openssl-debugsource",
+      "name": "openssl-debugsource",
+      "versionInfo": "3.0.7-18.el9_2",
+      "supplier": "Organization: Red Hat",
+      "downloadLocation": "NOASSERTION",
+      "packageFileName": "openssl-debugsource-3.0.7-18.el9_2.x86_64.rpm",
+      "licenseConcluded": "Apache-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-debugsource@3.0.7-18.el9_2?arch=x86_64&repository_id=rhel-9-for-x86_64-baseos-eus-source-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-debugsource@3.0.7-18.el9_2?arch=x86_64&repository_id=rhel-9-for-x86_64-baseos-aus-source-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-debugsource@3.0.7-18.el9_2?arch=x86_64&repository_id=rhel-9-for-x86_64-baseos-e4s-source-rpms"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "96e137f9561e7669417fe5998ec2aa6ba55a67aef0c2c205eede5a5a5941e8ac"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-x86_64-openssl-perl",
+      "name": "openssl-perl",
+      "versionInfo": "3.0.7-18.el9_2",
+      "supplier": "Organization: Red Hat",
+      "downloadLocation": "NOASSERTION",
+      "packageFileName": "openssl-perl-3.0.7-18.el9_2.x86_64.rpm",
+      "licenseConcluded": "Apache-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-perl@3.0.7-18.el9_2?arch=x86_64&repository_id=rhel-9-for-x86_64-baseos-eus-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-perl@3.0.7-18.el9_2?arch=x86_64&repository_id=rhel-9-for-x86_64-baseos-aus-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-perl@3.0.7-18.el9_2?arch=x86_64&repository_id=rhel-9-for-x86_64-baseos-e4s-rpms"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "403624aed89502e17352b50f00c413104c9be31307477d02c3a7ae78cfcb1ca4"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-x86_64-openssl-libs",
+      "name": "openssl-libs",
+      "versionInfo": "3.0.7-18.el9_2",
+      "supplier": "Organization: Red Hat",
+      "downloadLocation": "NOASSERTION",
+      "packageFileName": "openssl-libs-3.0.7-18.el9_2.x86_64.rpm",
+      "licenseConcluded": "Apache-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-libs@3.0.7-18.el9_2?arch=x86_64&repository_id=rhel-9-for-x86_64-baseos-eus-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-libs@3.0.7-18.el9_2?arch=x86_64&repository_id=rhel-9-for-x86_64-baseos-aus-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-libs@3.0.7-18.el9_2?arch=x86_64&repository_id=rhel-9-for-x86_64-baseos-e4s-rpms"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "73e869a62715910bdec02ee3f0275a81ca96f539a07aced314182b6f4dc8c828"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-x86_64-openssl",
+      "name": "openssl",
+      "versionInfo": "3.0.7-18.el9_2",
+      "supplier": "Organization: Red Hat",
+      "downloadLocation": "NOASSERTION",
+      "packageFileName": "openssl-3.0.7-18.el9_2.x86_64.rpm",
+      "licenseConcluded": "Apache-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=x86_64&repository_id=rhel-9-for-x86_64-baseos-eus-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=x86_64&repository_id=rhel-9-for-x86_64-baseos-aus-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=x86_64&repository_id=rhel-9-for-x86_64-baseos-e4s-rpms"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "96045880ef4a2167abe9ea14f2b325402996a7671df8f594924dc24b6c2263e4"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-x86_64-openssl-devel",
+      "name": "openssl-devel",
+      "versionInfo": "3.0.7-18.el9_2",
+      "supplier": "Organization: Red Hat",
+      "downloadLocation": "NOASSERTION",
+      "packageFileName": "openssl-devel-3.0.7-18.el9_2.x86_64.rpm",
+      "licenseConcluded": "Apache-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-devel@3.0.7-18.el9_2?arch=x86_64&repository_id=rhel-9-for-x86_64-baseos-eus-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-devel@3.0.7-18.el9_2?arch=x86_64&repository_id=rhel-9-for-x86_64-baseos-aus-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-devel@3.0.7-18.el9_2?arch=x86_64&repository_id=rhel-9-for-x86_64-baseos-e4s-rpms"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "72f42e7c9ade55a24d3c53f4370d5d6d3b2fe99a4735d564825556ccd4cc1df3"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-s390x-openssl-libs-debuginfo",
+      "name": "openssl-libs-debuginfo",
+      "versionInfo": "3.0.7-18.el9_2",
+      "supplier": "Organization: Red Hat",
+      "downloadLocation": "NOASSERTION",
+      "packageFileName": "openssl-libs-debuginfo-3.0.7-18.el9_2.s390x.rpm",
+      "licenseConcluded": "Apache-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-libs-debuginfo@3.0.7-18.el9_2?arch=s390x&repository_id=rhel-9-for-s390x-baseos-eus-debug-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-libs-debuginfo@3.0.7-18.el9_2?arch=s390x&repository_id=rhel-9-for-s390x-baseos-aus-debug-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-libs-debuginfo@3.0.7-18.el9_2?arch=s390x&repository_id=rhel-9-for-s390x-baseos-e4s-debug-rpms"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "bc5de92a3830cd99f7d291ccaafb5fd640127c8c1c925231e1e37d060a69563f"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-s390x-openssl-libs",
+      "name": "openssl-libs",
+      "versionInfo": "3.0.7-18.el9_2",
+      "supplier": "Organization: Red Hat",
+      "downloadLocation": "NOASSERTION",
+      "packageFileName": "openssl-libs-3.0.7-18.el9_2.s390x.rpm",
+      "licenseConcluded": "Apache-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-libs@3.0.7-18.el9_2?arch=s390x&repository_id=rhel-9-for-s390x-baseos-eus-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-libs@3.0.7-18.el9_2?arch=s390x&repository_id=rhel-9-for-s390x-baseos-aus-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-libs@3.0.7-18.el9_2?arch=s390x&repository_id=rhel-9-for-s390x-baseos-e4s-rpms"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "0543b42f6491762fab8defbc6ec68a30d8e17e2f55e50b29095c382a6ad5baf1"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-s390x-openssl-debugsource",
+      "name": "openssl-debugsource",
+      "versionInfo": "3.0.7-18.el9_2",
+      "supplier": "Organization: Red Hat",
+      "downloadLocation": "NOASSERTION",
+      "packageFileName": "openssl-debugsource-3.0.7-18.el9_2.s390x.rpm",
+      "licenseConcluded": "Apache-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-debugsource@3.0.7-18.el9_2?arch=s390x&repository_id=rhel-9-for-s390x-baseos-eus-source-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-debugsource@3.0.7-18.el9_2?arch=s390x&repository_id=rhel-9-for-s390x-baseos-aus-source-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-debugsource@3.0.7-18.el9_2?arch=s390x&repository_id=rhel-9-for-s390x-baseos-e4s-source-rpms"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "90ca984f844882a5c0678887851cc58be90a187c65ef010b866791c40116f7fc"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-s390x-openssl-devel",
+      "name": "openssl-devel",
+      "versionInfo": "3.0.7-18.el9_2",
+      "supplier": "Organization: Red Hat",
+      "downloadLocation": "NOASSERTION",
+      "packageFileName": "openssl-devel-3.0.7-18.el9_2.s390x.rpm",
+      "licenseConcluded": "Apache-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-devel@3.0.7-18.el9_2?arch=s390x&repository_id=rhel-9-for-s390x-baseos-eus-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-devel@3.0.7-18.el9_2?arch=s390x&repository_id=rhel-9-for-s390x-baseos-aus-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-devel@3.0.7-18.el9_2?arch=s390x&repository_id=rhel-9-for-s390x-baseos-e4s-rpms"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4a8588e587337d65cd2da98b0ba813a1e178a9b515c82bbc7fe96f1ba749b8fc"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-s390x-openssl-debuginfo",
+      "name": "openssl-debuginfo",
+      "versionInfo": "3.0.7-18.el9_2",
+      "supplier": "Organization: Red Hat",
+      "downloadLocation": "NOASSERTION",
+      "packageFileName": "openssl-debuginfo-3.0.7-18.el9_2.s390x.rpm",
+      "licenseConcluded": "Apache-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-debuginfo@3.0.7-18.el9_2?arch=s390x&repository_id=rhel-9-for-s390x-baseos-eus-debug-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-debuginfo@3.0.7-18.el9_2?arch=s390x&repository_id=rhel-9-for-s390x-baseos-aus-debug-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-debuginfo@3.0.7-18.el9_2?arch=s390x&repository_id=rhel-9-for-s390x-baseos-e4s-debug-rpms"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "0a2a6b1409b045894d15c1b05ff5be2c1feba0b2b5f2d3bbac9d2e44c93f0583"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-s390x-openssl",
+      "name": "openssl",
+      "versionInfo": "3.0.7-18.el9_2",
+      "supplier": "Organization: Red Hat",
+      "downloadLocation": "NOASSERTION",
+      "packageFileName": "openssl-3.0.7-18.el9_2.s390x.rpm",
+      "licenseConcluded": "Apache-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=s390x&repository_id=rhel-9-for-s390x-baseos-eus-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=s390x&repository_id=rhel-9-for-s390x-baseos-aus-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=s390x&repository_id=rhel-9-for-s390x-baseos-e4s-rpms"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "11c42421e6d07bca92122575ac023016471383f58575b2dd478a19e0ba7ce4db"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-s390x-openssl-perl",
+      "name": "openssl-perl",
+      "versionInfo": "3.0.7-18.el9_2",
+      "supplier": "Organization: Red Hat",
+      "downloadLocation": "NOASSERTION",
+      "packageFileName": "openssl-perl-3.0.7-18.el9_2.s390x.rpm",
+      "licenseConcluded": "Apache-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-perl@3.0.7-18.el9_2?arch=s390x&repository_id=rhel-9-for-s390x-baseos-eus-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-perl@3.0.7-18.el9_2?arch=s390x&repository_id=rhel-9-for-s390x-baseos-aus-rpms"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/redhat/openssl-perl@3.0.7-18.el9_2?arch=s390x&repository_id=rhel-9-for-s390x-baseos-e4s-rpms"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "6f885dd8acf32d367528f47f0289a04035fddc1eb83b720bc6889293b94892fc"
+        }
+      ]
+    }
+  ],
+  "files": [],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-SRPM"
+    },
+    {
+      "spdxElementId": "SPDXRef-Source0",
+      "relationshipType": "GENERATED_FROM",
+      "relatedSpdxElement": "SPDXRef-Source0-origin"
+    },
+    {
+      "spdxElementId": "SPDXRef-SRPM",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-Source0"
+    },
+    {
+      "spdxElementId": "SPDXRef-aarch64-openssl-perl",
+      "relationshipType": "GENERATED_FROM",
+      "relatedSpdxElement": "SPDXRef-SRPM"
+    },
+    {
+      "spdxElementId": "SPDXRef-aarch64-openssl-debuginfo",
+      "relationshipType": "GENERATED_FROM",
+      "relatedSpdxElement": "SPDXRef-SRPM"
+    },
+    {
+      "spdxElementId": "SPDXRef-aarch64-openssl-libs",
+      "relationshipType": "GENERATED_FROM",
+      "relatedSpdxElement": "SPDXRef-SRPM"
+    },
+    {
+      "spdxElementId": "SPDXRef-aarch64-openssl-libs-debuginfo",
+      "relationshipType": "GENERATED_FROM",
+      "relatedSpdxElement": "SPDXRef-SRPM"
+    },
+    {
+      "spdxElementId": "SPDXRef-aarch64-openssl",
+      "relationshipType": "GENERATED_FROM",
+      "relatedSpdxElement": "SPDXRef-SRPM"
+    },
+    {
+      "spdxElementId": "SPDXRef-aarch64-openssl-debugsource",
+      "relationshipType": "GENERATED_FROM",
+      "relatedSpdxElement": "SPDXRef-SRPM"
+    },
+    {
+      "spdxElementId": "SPDXRef-aarch64-openssl-devel",
+      "relationshipType": "GENERATED_FROM",
+      "relatedSpdxElement": "SPDXRef-SRPM"
+    },
+    {
+      "spdxElementId": "SPDXRef-ppc64le-openssl-perl",
+      "relationshipType": "GENERATED_FROM",
+      "relatedSpdxElement": "SPDXRef-SRPM"
+    },
+    {
+      "spdxElementId": "SPDXRef-ppc64le-openssl-libs",
+      "relationshipType": "GENERATED_FROM",
+      "relatedSpdxElement": "SPDXRef-SRPM"
+    },
+    {
+      "spdxElementId": "SPDXRef-ppc64le-openssl-devel",
+      "relationshipType": "GENERATED_FROM",
+      "relatedSpdxElement": "SPDXRef-SRPM"
+    },
+    {
+      "spdxElementId": "SPDXRef-ppc64le-openssl",
+      "relationshipType": "GENERATED_FROM",
+      "relatedSpdxElement": "SPDXRef-SRPM"
+    },
+    {
+      "spdxElementId": "SPDXRef-ppc64le-openssl-debuginfo",
+      "relationshipType": "GENERATED_FROM",
+      "relatedSpdxElement": "SPDXRef-SRPM"
+    },
+    {
+      "spdxElementId": "SPDXRef-ppc64le-openssl-debugsource",
+      "relationshipType": "GENERATED_FROM",
+      "relatedSpdxElement": "SPDXRef-SRPM"
+    },
+    {
+      "spdxElementId": "SPDXRef-ppc64le-openssl-libs-debuginfo",
+      "relationshipType": "GENERATED_FROM",
+      "relatedSpdxElement": "SPDXRef-SRPM"
+    },
+    {
+      "spdxElementId": "SPDXRef-i686-openssl-libs-debuginfo",
+      "relationshipType": "GENERATED_FROM",
+      "relatedSpdxElement": "SPDXRef-SRPM"
+    },
+    {
+      "spdxElementId": "SPDXRef-i686-openssl-libs",
+      "relationshipType": "GENERATED_FROM",
+      "relatedSpdxElement": "SPDXRef-SRPM"
+    },
+    {
+      "spdxElementId": "SPDXRef-i686-openssl-debugsource",
+      "relationshipType": "GENERATED_FROM",
+      "relatedSpdxElement": "SPDXRef-SRPM"
+    },
+    {
+      "spdxElementId": "SPDXRef-i686-openssl-devel",
+      "relationshipType": "GENERATED_FROM",
+      "relatedSpdxElement": "SPDXRef-SRPM"
+    },
+    {
+      "spdxElementId": "SPDXRef-i686-openssl-debuginfo",
+      "relationshipType": "GENERATED_FROM",
+      "relatedSpdxElement": "SPDXRef-SRPM"
+    },
+    {
+      "spdxElementId": "SPDXRef-i686-openssl",
+      "relationshipType": "GENERATED_FROM",
+      "relatedSpdxElement": "SPDXRef-SRPM"
+    },
+    {
+      "spdxElementId": "SPDXRef-i686-openssl-perl",
+      "relationshipType": "GENERATED_FROM",
+      "relatedSpdxElement": "SPDXRef-SRPM"
+    },
+    {
+      "spdxElementId": "SPDXRef-x86_64-openssl-libs-debuginfo",
+      "relationshipType": "GENERATED_FROM",
+      "relatedSpdxElement": "SPDXRef-SRPM"
+    },
+    {
+      "spdxElementId": "SPDXRef-x86_64-openssl-debuginfo",
+      "relationshipType": "GENERATED_FROM",
+      "relatedSpdxElement": "SPDXRef-SRPM"
+    },
+    {
+      "spdxElementId": "SPDXRef-x86_64-openssl-debugsource",
+      "relationshipType": "GENERATED_FROM",
+      "relatedSpdxElement": "SPDXRef-SRPM"
+    },
+    {
+      "spdxElementId": "SPDXRef-x86_64-openssl-perl",
+      "relationshipType": "GENERATED_FROM",
+      "relatedSpdxElement": "SPDXRef-SRPM"
+    },
+    {
+      "spdxElementId": "SPDXRef-x86_64-openssl-libs",
+      "relationshipType": "GENERATED_FROM",
+      "relatedSpdxElement": "SPDXRef-SRPM"
+    },
+    {
+      "spdxElementId": "SPDXRef-x86_64-openssl",
+      "relationshipType": "GENERATED_FROM",
+      "relatedSpdxElement": "SPDXRef-SRPM"
+    },
+    {
+      "spdxElementId": "SPDXRef-x86_64-openssl-devel",
+      "relationshipType": "GENERATED_FROM",
+      "relatedSpdxElement": "SPDXRef-SRPM"
+    },
+    {
+      "spdxElementId": "SPDXRef-s390x-openssl-libs-debuginfo",
+      "relationshipType": "GENERATED_FROM",
+      "relatedSpdxElement": "SPDXRef-SRPM"
+    },
+    {
+      "spdxElementId": "SPDXRef-s390x-openssl-libs",
+      "relationshipType": "GENERATED_FROM",
+      "relatedSpdxElement": "SPDXRef-SRPM"
+    },
+    {
+      "spdxElementId": "SPDXRef-s390x-openssl-debugsource",
+      "relationshipType": "GENERATED_FROM",
+      "relatedSpdxElement": "SPDXRef-SRPM"
+    },
+    {
+      "spdxElementId": "SPDXRef-s390x-openssl-devel",
+      "relationshipType": "GENERATED_FROM",
+      "relatedSpdxElement": "SPDXRef-SRPM"
+    },
+    {
+      "spdxElementId": "SPDXRef-s390x-openssl-debuginfo",
+      "relationshipType": "GENERATED_FROM",
+      "relatedSpdxElement": "SPDXRef-SRPM"
+    },
+    {
+      "spdxElementId": "SPDXRef-s390x-openssl",
+      "relationshipType": "GENERATED_FROM",
+      "relatedSpdxElement": "SPDXRef-SRPM"
+    },
+    {
+      "spdxElementId": "SPDXRef-s390x-openssl-perl",
+      "relationshipType": "GENERATED_FROM",
+      "relatedSpdxElement": "SPDXRef-SRPM"
+    }
+  ]
+}

--- a/internal/testing/testdata/exampledata/small-legal-cyclonedx.json
+++ b/internal/testing/testdata/exampledata/small-legal-cyclonedx.json
@@ -1,0 +1,269 @@
+{
+  "bomFormat" : "CycloneDX",
+  "specVersion" : "1.4",
+  "serialNumber" : "urn:uuid:0697952e-9848-4785-95bf-f81ff9731682",
+  "version" : 1,
+  "metadata" : {
+    "timestamp" : "2022-11-09T11:14:31Z",
+    "tools" : [
+      {
+        "vendor" : "OWASP Foundation",
+        "name" : "CycloneDX Maven plugin",
+        "version" : "2.7.1",
+        "hashes" : [
+          {
+            "alg" : "SHA3-512",
+            "content" : "72ea0ed8faa3cc4493db96d0223094842e7153890b091ff364040ad3ad89363157fc9d1bd852262124aec83134f0c19aa4fd0fa482031d38a76d74dfd36b7964"
+          }
+        ]
+      }
+    ],
+    "component" : {
+      "group" : "org.acme",
+      "name" : "getting-started",
+      "version" : "1.0.0-SNAPSHOT",
+      "licenses": [
+        {
+          "license": {
+            "id": "GPL-2.0"
+          }
+        },
+        {
+          "license": {
+            "id": "LGPL-3.0-or-later"
+          }
+        }
+      ],
+      "hashes" : [
+        {
+          "alg" : "SHA3-512",
+          "content" : "85240ed8faa3cc4493db96d0223094842e7153890b091ff364040ad3ad89363157fc9d1bd852262124aec83134f0c19aa4fd0fa482031d38a76d74dfd36b7964"
+        }
+      ],
+      "purl" : "pkg:maven/org.acme/getting-started@1.0.0-SNAPSHOT?type=jar",
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.acme/getting-started@1.0.0-SNAPSHOT?type=jar"
+    }
+  },
+  "components" : [
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-resteasy-reactive",
+      "version" : "2.13.4.Final",
+      "description" : "A JAX-RS implementation utilizing build time processing and Vert.x. This extension is not compatible with the quarkus-resteasy extension, or any of the extensions that depend on it.",
+      "scope" : "optional",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "bf39044af8c6ba66fc3beb034bc82ae8"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "615e56bdfeb591af8b5fdeadf019f8fa729643232d7e0768674411a7d959bb00e12e114280a6949f871514e1a86e01e0033372a0a826d15720050d7cffb80e69"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-resteasy-reactive@2.13.4.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "distribution",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/quarkusio/quarkus/issues/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/quarkusio/quarkus"
+        },
+        {
+          "type" : "website",
+          "url" : "http://www.jboss.org"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-resteasy-reactive@2.13.4.Final?type=jar"
+    },
+    {
+      "publisher" : "SmallRye",
+      "group" : "io.smallrye.reactive",
+      "name" : "smallrye-mutiny-vertx-uri-template",
+      "version" : "2.27.0",
+      "description" : "SmallRye Build Parent POM",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "8756663af131035a2090d83f5f1b4054"
+        }
+      ],
+      "licenses" : [
+        {
+          "expression" : "Apache-2.0 AND (MIT OR GPL-2.0-only)"
+        }
+      ],
+      "purl" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-uri-template@2.27.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://wwww.smallrye.io"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/smallrye/smallrye-mutiny-vertx-bindings/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/smallrye/smallrye-mutiny-vertx-bindings"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-uri-template@2.27.0?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "quarkus-resteasy-reactive-common",
+      "version" : "2.13.4.Final",
+      "description" : "Common runtime parts of Quarkus RESTEasy Reactive",
+      "hashes" : [
+        {
+          "alg" : "SHA3-512",
+          "content" : "54ffa51cb2fb25e70871e4b69489814ebb3d23d4f958e83ef1f811c00a8753c6c30c5bbc1b48b6427357eb70e5c35c7b357f5252e246fbfa00b90ee22ad095e1"
+        }
+      ],
+      "licenses" : [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        },
+        {
+          "license": {
+            "name": "Custom license",
+            "text": {
+              "content": "This is the text of the custom license I wrote"
+            }
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.quarkus/quarkus-resteasy-reactive-common@2.13.4.Final?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.quarkus/quarkus-resteasy-reactive-common@2.13.4.Final?type=jar"
+    },
+    {
+      "publisher" : "JBoss by Red Hat",
+      "group" : "io.quarkus",
+      "name" : "netbase",
+      "version" : ".3",
+      "description" : "Common runtime parts of Quarkus RESTEasy Reactive",
+      "hashes" : [
+        {
+          "alg" : "SHA3-512",
+          "content" : "87gna51cb2fb25e70871e4b69489814ebb3d23d4f958e83ef1f811c00a8753c6c30c5bbc1b48b6427357eb70e5c35c7b357f5252e246fbfa00b90ee22ad095e1"
+        }
+      ],
+      "licenses" : [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        },
+        {
+          "license": {
+            "name": "Custom license",
+            "text": {
+              "content": "This is the text of the custom license I wrote"
+            }
+          }
+        }
+      ],
+      "purl" : "pkg:deb/debian/netbase@6.3?arch=all\u0026distro=debian-11",
+      "externalReferences" : [
+        {
+          "type" : "mailing-list",
+          "url" : "http://lists.jboss.org/pipermail/jboss-user/"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:deb/debian/netbase@6.3?arch=all\u0026distro=debian-11\u0026package-id=913906225fd3778b"
+    },
+    {
+      "publisher" : "Eclipse Foundation",
+      "group" : "org.eclipse.microprofile.context-propagation",
+      "name" : "microprofile-context-propagation-api",
+      "version" : "1.2",
+      "description" : "MicroProfile Context Propagation :: API",
+      "hashes" : [
+        {
+          "alg" : "SHA-256",
+          "content" : "1576e21f3bf9cc3a3092e7cd40e9c9fef70532223af98a9218c1c9c885a71251"
+        }
+      ],
+      "licenses" : [
+        {
+          "license": {
+            "name": "Custom license",
+            "bom-ref" : "LicenseRef-a7fb6b15"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.eclipse.org/"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse/microprofile-context-propagation/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse/microprofile-context-propagation"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.2?type=jar"
+    }
+  ],
+  "dependencies" : [
+    {
+      "ref" : "pkg:maven/org.acme/getting-started@1.0.0-SNAPSHOT?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus/quarkus-resteasy-reactive@2.13.4.Final?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.quarkus/quarkus-resteasy-reactive@2.13.4.Final?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.quarkus/quarkus-resteasy-reactive-common@2.13.4.Final?type=jar"
+      ]
+    }
+  ]
+}

--- a/internal/testing/testdata/testdata.go
+++ b/internal/testing/testdata/testdata.go
@@ -173,6 +173,9 @@ var (
 	//go:embed exampledata/ingest_predicates.json
 	IngestPredicatesExample []byte
 
+	//go:embed exampledata/small-legal-cyclonedx.json
+	CycloneDXLegalExample []byte
+
 	// json format
 	json = jsoniter.ConfigCompatibleWithStandardLibrary
 	// CycloneDX VEX testdata unaffected
@@ -968,6 +971,8 @@ var (
 
 	cdxBasefilesPack, _ = asmhelpers.PurlToPkg("pkg:deb/debian/base-files@11.1+deb11u5?arch=amd64&distro=debian-11")
 
+	cdxSmallRye, _ = asmhelpers.PurlToPkg("pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-uri-template@2.27.0?type=jar")
+
 	CdxDeps = []assembler.IsDependencyIngest{
 		{
 			Pkg:             cdxTopLevelPack,
@@ -1027,7 +1032,9 @@ var (
 
 	cdxReactiveCommonPack, _ = asmhelpers.PurlToPkg("pkg:maven/io.quarkus/quarkus-resteasy-reactive-common@2.13.4.Final?type=jar")
 
-	CdxQuarkusDeps = []assembler.IsDependencyIngest{
+	cdxMicroprofilePack, _ = asmhelpers.PurlToPkg("pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.2?type=jar")
+
+	cdxQuarkusDeps = []assembler.IsDependencyIngest{
 		{
 			Pkg:             cdxTopQuarkusPack,
 			DepPkg:          cdxResteasyPack,
@@ -1059,8 +1066,39 @@ var (
 			},
 		},
 	}
+	lvUnknown       = "UNKNOWN"
+	cdxQuarkusLegal = []assembler.CertifyLegalIngest{
+		{
+			Pkg: cdxResteasyPack,
+			Declared: []model.LicenseInputSpec{
+				{
+					Name:        "Apache-2.0",
+					ListVersion: &lvUnknown,
+				},
+			},
+			CertifyLegal: &model.CertifyLegalInputSpec{
+				DeclaredLicense: "Apache-2.0",
+				Justification:   "Found in CycloneDX document",
+				TimeScanned:     cdxQuarkusTime,
+			},
+		},
+		{
+			Pkg: cdxReactiveCommonPack,
+			Declared: []model.LicenseInputSpec{
+				{
+					Name:        "Apache-2.0",
+					ListVersion: &lvUnknown,
+				},
+			},
+			CertifyLegal: &model.CertifyLegalInputSpec{
+				DeclaredLicense: "Apache-2.0",
+				Justification:   "Found in CycloneDX document",
+				TimeScanned:     cdxQuarkusTime,
+			},
+		},
+	}
 
-	CdxQuarkusOccurrence = []assembler.IsOccurrenceIngest{
+	cdxQuarkusOccurrence = []assembler.IsOccurrenceIngest{
 		{
 			Pkg: cdxTopQuarkusPack,
 			Artifact: &model.ArtifactInputSpec{
@@ -1097,7 +1135,7 @@ var (
 
 	cdxQuarkusTime, _ = time.Parse(time.RFC3339, "2022-11-09T11:14:31Z")
 
-	CdxQuarkusHasSBOM = []assembler.HasSBOMIngest{
+	cdxQuarkusHasSBOM = []assembler.HasSBOMIngest{
 		{
 			Artifact: &model.ArtifactInputSpec{
 				Algorithm: "sha3-512",
@@ -1114,9 +1152,262 @@ var (
 	}
 
 	CdxQuarkusIngestionPredicates = assembler.IngestPredicates{
-		IsDependency: CdxQuarkusDeps,
-		IsOccurrence: CdxQuarkusOccurrence,
-		HasSBOM:      CdxQuarkusHasSBOM,
+		IsDependency: cdxQuarkusDeps,
+		IsOccurrence: cdxQuarkusOccurrence,
+		HasSBOM:      cdxQuarkusHasSBOM,
+		CertifyLegal: cdxQuarkusLegal,
+	}
+
+	cdxLegalDeps = []assembler.IsDependencyIngest{
+		{
+			Pkg:             cdxTopQuarkusPack,
+			DepPkg:          cdxResteasyPack,
+			DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion},
+			IsDependency: &model.IsDependencyInputSpec{
+				DependencyType: model.DependencyTypeDirect,
+				VersionRange:   "2.13.4.Final",
+				Justification:  isCDXDepJustifyDependsJustification,
+			},
+		},
+		{
+			Pkg:             cdxTopQuarkusPack,
+			DepPkg:          cdxReactiveCommonPack,
+			DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion},
+			IsDependency: &model.IsDependencyInputSpec{
+				DependencyType: model.DependencyTypeIndirect,
+				VersionRange:   "2.13.4.Final",
+				Justification:  isCDXDepJustifyDependsJustification,
+			},
+		},
+		{
+			Pkg:             cdxResteasyPack,
+			DepPkg:          cdxReactiveCommonPack,
+			DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion},
+			IsDependency: &model.IsDependencyInputSpec{
+				DependencyType: model.DependencyTypeDirect,
+				VersionRange:   "2.13.4.Final",
+				Justification:  isCDXDepJustifyDependsJustification,
+			},
+		},
+		{
+			Pkg:             cdxTopQuarkusPack,
+			DepPkg:          cdxSmallRye,
+			DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion},
+			IsDependency: &model.IsDependencyInputSpec{
+				DependencyType: model.DependencyTypeUnknown,
+				VersionRange:   "2.27.0",
+				Justification:  isDepJustifyTopPkgJustification,
+			},
+		},
+		{
+			Pkg:             cdxTopQuarkusPack,
+			DepPkg:          cdxNetbasePack,
+			DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion},
+			IsDependency: &model.IsDependencyInputSpec{
+				DependencyType: model.DependencyTypeUnknown,
+				VersionRange:   "6.3",
+				Justification:  isDepJustifyTopPkgJustification,
+			},
+		},
+		{
+			Pkg:             cdxTopQuarkusPack,
+			DepPkg:          cdxMicroprofilePack,
+			DepPkgMatchFlag: model.MatchFlags{Pkg: model.PkgMatchTypeSpecificVersion},
+			IsDependency: &model.IsDependencyInputSpec{
+				DependencyType: model.DependencyTypeUnknown,
+				VersionRange:   "1.2",
+				Justification:  isDepJustifyTopPkgJustification,
+			},
+		},
+	}
+	customLincenseText   = "This is the text of the custom license I wrote"
+	cdxLegalCertifyLegal = []assembler.CertifyLegalIngest{
+		{
+			Pkg: cdxNetbasePack,
+			Declared: []model.LicenseInputSpec{
+				{
+					Name:        "Apache-2.0",
+					ListVersion: &lvUnknown,
+				},
+				{
+					Name:   "LicenseRef-a7fb6b15",
+					Inline: &customLincenseText,
+				},
+			},
+			CertifyLegal: &model.CertifyLegalInputSpec{
+				DeclaredLicense: "Apache-2.0 AND LicenseRef-a7fb6b15",
+				Justification:   "Found in CycloneDX document",
+				TimeScanned:     cdxQuarkusTime,
+			},
+		},
+		{
+			Pkg: cdxResteasyPack,
+			Declared: []model.LicenseInputSpec{
+				{
+					Name:        "Apache-2.0",
+					ListVersion: &lvUnknown,
+				},
+			},
+			CertifyLegal: &model.CertifyLegalInputSpec{
+				DeclaredLicense: "Apache-2.0",
+				Justification:   "Found in CycloneDX document",
+				TimeScanned:     cdxQuarkusTime,
+			},
+		},
+		{
+			Pkg: cdxReactiveCommonPack,
+			Declared: []model.LicenseInputSpec{
+				{
+					Name:        "Apache-2.0",
+					ListVersion: &lvUnknown,
+				},
+				{
+					Name:   "LicenseRef-a7fb6b15",
+					Inline: &customLincenseText,
+				},
+			},
+			CertifyLegal: &model.CertifyLegalInputSpec{
+				DeclaredLicense: "Apache-2.0 AND LicenseRef-a7fb6b15",
+				Justification:   "Found in CycloneDX document",
+				TimeScanned:     cdxQuarkusTime,
+			},
+		},
+		{
+			Pkg: cdxSmallRye,
+			Declared: []model.LicenseInputSpec{
+				{
+					Name:        "Apache-2.0",
+					ListVersion: &lvUnknown,
+				},
+				{
+					Name:        "MIT",
+					ListVersion: &lvUnknown,
+				},
+				{
+					Name:        "GPL-2.0-only",
+					ListVersion: &lvUnknown,
+				},
+			},
+			CertifyLegal: &model.CertifyLegalInputSpec{
+				DeclaredLicense: "Apache-2.0 AND (MIT OR GPL-2.0-only)",
+				Justification:   "Found in CycloneDX document",
+				TimeScanned:     cdxQuarkusTime,
+			},
+		},
+		{
+			Pkg: cdxTopQuarkusPack,
+			Declared: []model.LicenseInputSpec{
+				{
+					Name:        "GPL-2.0",
+					ListVersion: &lvUnknown,
+				},
+				{
+					Name:        "LGPL-3.0-or-later",
+					ListVersion: &lvUnknown,
+				},
+			},
+			CertifyLegal: &model.CertifyLegalInputSpec{
+				DeclaredLicense: "GPL-2.0 AND LGPL-3.0-or-later",
+				Justification:   "Found in CycloneDX document",
+				TimeScanned:     cdxQuarkusTime,
+			},
+		},
+		{
+			Pkg: cdxMicroprofilePack,
+			Declared: []model.LicenseInputSpec{
+				{
+					Name:   "LicenseRef-a7fb6b15",
+					Inline: &customLincenseText,
+				},
+			},
+			CertifyLegal: &model.CertifyLegalInputSpec{
+				DeclaredLicense: "LicenseRef-a7fb6b15",
+				Justification:   "Found in CycloneDX document",
+				TimeScanned:     cdxQuarkusTime,
+			},
+		},
+	}
+
+	cdxLegalOccurrence = []assembler.IsOccurrenceIngest{
+		{
+			Pkg: cdxTopQuarkusPack,
+			Artifact: &model.ArtifactInputSpec{
+				Algorithm: "sha3-512",
+				Digest:    "85240ed8faa3cc4493db96d0223094842e7153890b091ff364040ad3ad89363157fc9d1bd852262124aec83134f0c19aa4fd0fa482031d38a76d74dfd36b7964",
+			},
+			IsOccurrence: isOccurrenceJustifyTopPkg,
+		},
+		{
+			Pkg: cdxResteasyPack,
+			Artifact: &model.ArtifactInputSpec{
+				Algorithm: "md5",
+				Digest:    "bf39044af8c6ba66fc3beb034bc82ae8",
+			},
+			IsOccurrence: isOccurrenceJustifyTopPkg,
+		},
+		{
+			Pkg: cdxResteasyPack,
+			Artifact: &model.ArtifactInputSpec{
+				Algorithm: "sha3-512",
+				Digest:    "615e56bdfeb591af8b5fdeadf019f8fa729643232d7e0768674411a7d959bb00e12e114280a6949f871514e1a86e01e0033372a0a826d15720050d7cffb80e69",
+			},
+			IsOccurrence: isOccurrenceJustifyTopPkg,
+		},
+		{
+			Pkg: cdxReactiveCommonPack,
+			Artifact: &model.ArtifactInputSpec{
+				Algorithm: "sha3-512",
+				Digest:    "54ffa51cb2fb25e70871e4b69489814ebb3d23d4f958e83ef1f811c00a8753c6c30c5bbc1b48b6427357eb70e5c35c7b357f5252e246fbfa00b90ee22ad095e1",
+			},
+			IsOccurrence: isOccurrenceJustifyTopPkg,
+		},
+		{
+			Pkg: cdxSmallRye,
+			Artifact: &model.ArtifactInputSpec{
+				Algorithm: "md5",
+				Digest:    "8756663af131035a2090d83f5f1b4054",
+			},
+			IsOccurrence: isOccurrenceJustifyTopPkg,
+		},
+		{
+			Pkg: cdxNetbasePack,
+			Artifact: &model.ArtifactInputSpec{
+				Algorithm: "sha3-512",
+				Digest:    "87gna51cb2fb25e70871e4b69489814ebb3d23d4f958e83ef1f811c00a8753c6c30c5bbc1b48b6427357eb70e5c35c7b357f5252e246fbfa00b90ee22ad095e1",
+			},
+			IsOccurrence: isOccurrenceJustifyTopPkg,
+		},
+		{
+			Pkg: cdxMicroprofilePack,
+			Artifact: &model.ArtifactInputSpec{
+				Algorithm: "sha-256",
+				Digest:    "1576e21f3bf9cc3a3092e7cd40e9c9fef70532223af98a9218c1c9c885a71251",
+			},
+			IsOccurrence: isOccurrenceJustifyTopPkg,
+		},
+	}
+
+	cdxLegalHasSBOM = []assembler.HasSBOMIngest{
+		{
+			Artifact: &model.ArtifactInputSpec{
+				Algorithm: "sha3-512",
+				Digest:    "85240ed8faa3cc4493db96d0223094842e7153890b091ff364040ad3ad89363157fc9d1bd852262124aec83134f0c19aa4fd0fa482031d38a76d74dfd36b7964",
+			},
+			HasSBOM: &model.HasSBOMInputSpec{
+				Uri:              "urn:uuid:0697952e-9848-4785-95bf-f81ff9731682",
+				Algorithm:        "sha256",
+				Digest:           "b9691aeacfe8adca01097f2e2af3484038df6e367524f9c38f6e1696f8971ed9",
+				DownloadLocation: "",
+				KnownSince:       cdxQuarkusTime,
+			},
+		},
+	}
+
+	CdxQuarkusLegalPredicates = assembler.IngestPredicates{
+		IsDependency: cdxLegalDeps,
+		IsOccurrence: cdxLegalOccurrence,
+		HasSBOM:      cdxLegalHasSBOM,
+		CertifyLegal: cdxLegalCertifyLegal,
 	}
 
 	cdxWebAppPackage, _ = asmhelpers.PurlToPkg("pkg:npm/web-app@1.0.0")
@@ -1172,8 +1463,26 @@ var (
 		},
 	}
 
+	quarkusParentPackageLegal = []assembler.CertifyLegalIngest{
+		{
+			Pkg: quarkusParentPackage,
+			Declared: []model.LicenseInputSpec{
+				{
+					Name:        "Apache-2.0",
+					ListVersion: &lvUnknown,
+				},
+			},
+			CertifyLegal: &model.CertifyLegalInputSpec{
+				DeclaredLicense: "Apache-2.0",
+				Justification:   "Found in CycloneDX document",
+				TimeScanned:     quarkusTime,
+			},
+		},
+	}
+
 	CdxEmptyIngestionPredicates = assembler.IngestPredicates{
-		HasSBOM: quarkusParentPackageHasSBOM,
+		HasSBOM:      quarkusParentPackageHasSBOM,
+		CertifyLegal: quarkusParentPackageLegal,
 	}
 
 	// ceritifer testdata

--- a/pkg/assembler/clients/generated/operations.go
+++ b/pkg/assembler/clients/generated/operations.go
@@ -1036,7 +1036,7 @@ type AllCertifyLegalTree struct {
 	Id string `json:"id"`
 	// The package version or source that is attested
 	Subject AllCertifyLegalTreeSubjectPackageOrSource `json:"-"`
-	// The license expression as delcared
+	// The license expression as declared
 	DeclaredLicense string `json:"declaredLicense"`
 	// A list of license objects found in the declared license expression
 	DeclaredLicenses []AllCertifyLegalTreeDeclaredLicensesLicense `json:"declaredLicenses"`

--- a/pkg/assembler/clients/helpers/bulk.go
+++ b/pkg/assembler/clients/helpers/bulk.go
@@ -1169,8 +1169,8 @@ func ingestCertifyLegals(ctx context.Context, client graphql.Client, v []assembl
 				return fmt.Errorf("failed to find ingested Package ID for certifyLegal: %s", helpers.GetKey[*model.PkgInputSpec, helpers.PkgIds](ingest.Pkg, helpers.PkgClientKey).VersionId)
 			}
 
-			// Declared Licenses
-			var pkgDecList []model.IDorLicenseInput
+			// Declared Licenses - initialized as it cannot be nil
+			pkgDecList := make([]model.IDorLicenseInput, 0)
 			for _, dec := range ingest.Declared {
 				if licID, found := licenseInputMap[helpers.GetKey[*model.LicenseInputSpec, string](&dec, helpers.LicenseClientKey)]; found {
 					pkgDecList = append(pkgDecList, *licID)
@@ -1180,8 +1180,8 @@ func ingestCertifyLegals(ctx context.Context, client graphql.Client, v []assembl
 			}
 			pkgDecIDs = append(pkgDecIDs, pkgDecList)
 
-			// Discovered Licenses
-			var pkgDisList []model.IDorLicenseInput
+			// Discovered Licenses - initialized as it cannot be nil
+			pkgDisList := make([]model.IDorLicenseInput, 0)
 			for _, dis := range ingest.Discovered {
 				if licID, found := licenseInputMap[helpers.GetKey[*model.LicenseInputSpec, string](&dis, helpers.LicenseClientKey)]; found {
 					pkgDisList = append(pkgDisList, *licID)
@@ -1198,8 +1198,8 @@ func ingestCertifyLegals(ctx context.Context, client graphql.Client, v []assembl
 				return fmt.Errorf("failed to find ingested Source ID for certifyLegal: %s", helpers.GetKey[*model.SourceInputSpec, helpers.SrcIds](ingest.Src, helpers.SrcClientKey).NameId)
 			}
 
-			// Declared Licenses
-			var srcDecList []model.IDorLicenseInput
+			// Declared Licenses - initialized as it cannot be nil
+			srcDecList := make([]model.IDorLicenseInput, 0)
 			for _, dec := range ingest.Declared {
 				if licID, found := licenseInputMap[helpers.GetKey[*model.LicenseInputSpec, string](&dec, helpers.LicenseClientKey)]; found {
 					srcDecList = append(srcDecList, *licID)
@@ -1209,8 +1209,8 @@ func ingestCertifyLegals(ctx context.Context, client graphql.Client, v []assembl
 			}
 			srcDecIDs = append(srcDecIDs, srcDecList)
 
-			// Discovered Licenses
-			var srcDisList []model.IDorLicenseInput
+			// Discovered Licenses - initialized as it cannot be nil
+			srcDisList := make([]model.IDorLicenseInput, 0)
 			for _, dis := range ingest.Discovered {
 				if licID, found := licenseInputMap[helpers.GetKey[*model.LicenseInputSpec, string](&dis, helpers.LicenseClientKey)]; found {
 					srcDisList = append(srcDisList, *licID)

--- a/pkg/assembler/graphql/generated/root_.generated.go
+++ b/pkg/assembler/graphql/generated/root_.generated.go
@@ -5100,7 +5100,7 @@ type CertifyLegal {
   id: ID!
   "The package version or source that is attested"
   subject: PackageOrSource!
-  "The license expression as delcared"
+  "The license expression as declared"
   declaredLicense: String!
   "A list of license objects found in the declared license expression"
   declaredLicenses: [License!]!

--- a/pkg/assembler/graphql/model/nodes.go
+++ b/pkg/assembler/graphql/model/nodes.go
@@ -326,7 +326,7 @@ type CertifyLegal struct {
 	ID string `json:"id"`
 	// The package version or source that is attested
 	Subject PackageOrSource `json:"subject"`
-	// The license expression as delcared
+	// The license expression as declared
 	DeclaredLicense string `json:"declaredLicense"`
 	// A list of license objects found in the declared license expression
 	DeclaredLicenses []*License `json:"declaredLicenses"`

--- a/pkg/assembler/graphql/schema/certifyLegal.graphql
+++ b/pkg/assembler/graphql/schema/certifyLegal.graphql
@@ -37,7 +37,7 @@ type CertifyLegal {
   id: ID!
   "The package version or source that is attested"
   subject: PackageOrSource!
-  "The license expression as delcared"
+  "The license expression as declared"
   declaredLicense: String!
   "A list of license objects found in the declared license expression"
   declaredLicenses: [License!]!

--- a/pkg/ingestor/parser/common/license.go
+++ b/pkg/ingestor/parser/common/license.go
@@ -21,7 +21,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/guacsec/guac/pkg/assembler/clients/generated"
+	model "github.com/guacsec/guac/pkg/assembler/clients/generated"
 )
 
 var ignore = []string{
@@ -69,20 +69,36 @@ var ignore = []string{
 // "Universal-FOSS-exception-1.0",
 // "WxWindows-exception-3.1",
 
-func ParseLicenses(exp string, lv string) []generated.LicenseInputSpec {
+func ParseLicenses(exp string, lv *string, inLineMap map[string]string) []model.LicenseInputSpec {
 	if exp == "" {
 		return nil
 	}
-	var rv []generated.LicenseInputSpec
+	var rv []model.LicenseInputSpec
+	unknown := "UNKNOWN"
 	for _, part := range strings.Split(exp, " ") {
 		p := strings.Trim(part, "()+")
 		if slices.Contains(ignore, p) {
 			continue
 		}
-		rv = append(rv, generated.LicenseInputSpec{
-			Name:        p,
-			ListVersion: &lv,
-		})
+		var license model.LicenseInputSpec
+		if inline, ok := inLineMap[p]; ok {
+			license = model.LicenseInputSpec{
+				Name:        p,
+				Inline:      &inline,
+				ListVersion: lv,
+			}
+		} else if lv != nil {
+			license = model.LicenseInputSpec{
+				Name:        p,
+				ListVersion: lv,
+			}
+		} else {
+			license = model.LicenseInputSpec{
+				Name:        p,
+				ListVersion: &unknown,
+			}
+		}
+		rv = append(rv, license)
 	}
 	return rv
 }
@@ -92,4 +108,8 @@ func HashLicense(inline string) string {
 	h.Write([]byte(inline))
 	s := h.Sum32()
 	return fmt.Sprintf("LicenseRef-%x", s)
+}
+
+func CombineLicense(licenses []string) string {
+	return strings.Join(licenses, " AND ")
 }

--- a/pkg/ingestor/parser/common/license_test.go
+++ b/pkg/ingestor/parser/common/license_test.go
@@ -1,0 +1,42 @@
+//
+// Copyright 2023 The GUAC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestCombineLicense(t *testing.T) {
+	tests := []struct {
+		name     string
+		licenses []string
+		want     string
+	}{{
+		name:     "multiple",
+		licenses: []string{"GPL-2.0", "LGPL-3.0-or-later"},
+		want:     "GPL-2.0 AND LGPL-3.0-or-later",
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CombineLicense(tt.licenses)
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
@@ -54,9 +54,12 @@ type cyclonedxParser struct {
 	doc               *processor.Document
 	packagePackages   map[string][]*model.PkgInputSpec
 	packageArtifacts  map[string][]*model.ArtifactInputSpec
+	packageLegals     map[string][]*model.CertifyLegalInputSpec
+	licenseInLine     map[string]string
 	identifierStrings *common.IdentifierStrings
 	cdxBom            *cdx.BOM
 	vulnData          vulnData
+	timestamp         time.Time
 }
 
 type vulnData struct {
@@ -69,6 +72,8 @@ func NewCycloneDXParser() common.DocumentParser {
 	return &cyclonedxParser{
 		packagePackages:   map[string][]*model.PkgInputSpec{},
 		packageArtifacts:  map[string][]*model.ArtifactInputSpec{},
+		packageLegals:     map[string][]*model.CertifyLegalInputSpec{},
+		licenseInLine:     map[string]string{},
 		identifierStrings: &common.IdentifierStrings{},
 	}
 }
@@ -81,6 +86,7 @@ func (c *cyclonedxParser) Parse(ctx context.Context, doc *processor.Document) er
 		return fmt.Errorf("failed to parse cyclonedx BOM: %w", err)
 	}
 	c.cdxBom = cdxBom
+
 	if err := c.getTopLevelPackage(); err != nil {
 		return err
 	}
@@ -102,6 +108,17 @@ func (c *cyclonedxParser) GetIdentities(ctx context.Context) []common.TrustInfor
 func (c *cyclonedxParser) getTopLevelPackage() error {
 	if c.cdxBom.Metadata == nil {
 		return nil
+	}
+
+	if c.cdxBom.Metadata.Timestamp == "" {
+		// set the time to zero time if timestamp is not provided
+		c.timestamp = zeroTime
+	} else {
+		timestamp, err := time.Parse(time.RFC3339, c.cdxBom.Metadata.Timestamp)
+		if err != nil {
+			return fmt.Errorf("SPDX document had invalid created time %q : %w", c.cdxBom.Metadata.Timestamp, err)
+		}
+		c.timestamp = timestamp
 	}
 
 	if c.cdxBom.Metadata.Component != nil {
@@ -134,6 +151,11 @@ func (c *cyclonedxParser) getTopLevelPackage() error {
 				}
 				c.packageArtifacts[c.cdxBom.Metadata.Component.BOMRef] = append(c.packageArtifacts[c.cdxBom.Metadata.Component.BOMRef], artifact)
 			}
+		}
+
+		// get top level licenses
+		if err := c.getLicenseInformation(*c.cdxBom.Metadata.Component); err != nil {
+			return fmt.Errorf("failed to get license information for top level package with error: %w", err)
 		}
 		return nil
 	} else {
@@ -180,42 +202,114 @@ func traverseComponents(c cyclonedxParser, components *[]cdx.Component) error {
 			// skipping over the "operating-system" type as it does not contain
 			// the required purl for package node. Currently there is no use-case
 			// to capture OS for GUAC.
-			if comp.Type != cdx.ComponentTypeOS {
-				purl := comp.PackageURL
-				if purl == "" {
-					if comp.Type == cdx.ComponentTypeContainer {
-						purl = parseContainerType(comp.Name, comp.Version, false)
-					} else if comp.Type == cdx.ComponentTypeFile {
-						purl = guacCDXFilePurl(comp.Name, comp.Version, false)
-					} else {
-						purl = asmhelpers.GuacPkgPurl(comp.Name, &comp.Version)
-					}
-				}
-				pkg, err := asmhelpers.PurlToPkg(purl)
-				if err != nil {
-					return err
-				}
-				c.packagePackages[comp.BOMRef] = append(c.packagePackages[comp.BOMRef], pkg)
-				c.identifierStrings.PurlStrings = append(c.identifierStrings.PurlStrings, comp.PackageURL)
+			if comp.Type == cdx.ComponentTypeOS {
+				continue
+			}
 
-				// if checksums exists create an artifact for each of them
-				if comp.Hashes != nil {
-					for _, checksum := range *comp.Hashes {
-						artifact := &model.ArtifactInputSpec{
-							Algorithm: strings.ToLower(string(checksum.Algorithm)),
-							Digest:    checksum.Value,
-						}
-						c.packageArtifacts[comp.BOMRef] = append(c.packageArtifacts[comp.BOMRef], artifact)
-					}
+			purl := comp.PackageURL
+			if purl == "" {
+				if comp.Type == cdx.ComponentTypeContainer {
+					purl = parseContainerType(comp.Name, comp.Version, false)
+				} else if comp.Type == cdx.ComponentTypeFile {
+					purl = guacCDXFilePurl(comp.Name, comp.Version, false)
+				} else {
+					purl = asmhelpers.GuacPkgPurl(comp.Name, &comp.Version)
 				}
 				err = traverseComponents(c, comp.Components)
 				if err != nil {
 					return err
 				}
 			}
+			pkg, err := asmhelpers.PurlToPkg(purl)
+			if err != nil {
+				return err
+			}
+			c.packagePackages[comp.BOMRef] = append(c.packagePackages[comp.BOMRef], pkg)
+			c.identifierStrings.PurlStrings = append(c.identifierStrings.PurlStrings, comp.PackageURL)
+
+			// if checksums exists create an artifact for each of them
+			if comp.Hashes != nil {
+				for _, checksum := range *comp.Hashes {
+					artifact := &model.ArtifactInputSpec{
+						Algorithm: strings.ToLower(string(checksum.Algorithm)),
+						Digest:    checksum.Value,
+					}
+					c.packageArtifacts[comp.BOMRef] = append(c.packageArtifacts[comp.BOMRef], artifact)
+				}
+			}
+			// get other component packages
+			if err := c.getLicenseInformation(comp); err != nil {
+				return fmt.Errorf("failed to get license information for component package with error: %w", err)
+			}
 		}
 	}
 	return nil
+}
+
+func (c *cyclonedxParser) getLicenseInformation(comp cdx.Component) error {
+	// legal information from CDX component
+	if comp.Licenses != nil {
+		compLicenses := *comp.Licenses
+		const justification string = "Found in CycloneDX document"
+
+		if len(compLicenses) == 1 {
+			if compLicenses[0].Expression != "" {
+				cl := &model.CertifyLegalInputSpec{
+					Justification:     justification,
+					DeclaredLicense:   compLicenses[0].Expression,
+					DiscoveredLicense: "",
+					TimeScanned:       c.timestamp,
+					Attribution:       comp.Copyright,
+				}
+				c.packageLegals[comp.BOMRef] = append(c.packageLegals[comp.BOMRef], cl)
+			} else {
+				license := getLicenseFromName(c, compLicenses[0])
+				if license != "" {
+					cl := &model.CertifyLegalInputSpec{
+						Justification:     justification,
+						DeclaredLicense:   license,
+						DiscoveredLicense: "",
+						TimeScanned:       c.timestamp,
+						Attribution:       comp.Copyright,
+					}
+					c.packageLegals[comp.BOMRef] = append(c.packageLegals[comp.BOMRef], cl)
+				}
+			}
+		} else {
+			var licenses []string
+			for _, compLicense := range compLicenses {
+				licenses = append(licenses, getLicenseFromName(c, compLicense))
+			}
+			if len(licenses) > 0 {
+				cl := &model.CertifyLegalInputSpec{
+					Justification:     justification,
+					DeclaredLicense:   common.CombineLicense(licenses),
+					DiscoveredLicense: "",
+					TimeScanned:       c.timestamp,
+					Attribution:       comp.Copyright,
+				}
+				c.packageLegals[comp.BOMRef] = append(c.packageLegals[comp.BOMRef], cl)
+			}
+		}
+	}
+	return nil
+}
+
+func getLicenseFromName(c *cyclonedxParser, compLicense cdx.LicenseChoice) string {
+	var license string
+	if compLicense.License.Name != "" && compLicense.License.Name != "UNKNOWN" {
+		if compLicense.License.Text != nil {
+			license = common.HashLicense(compLicense.License.Name)
+			c.licenseInLine[license] = compLicense.License.Text.Content
+		} else if compLicense.License.BOMRef != "" {
+			license = compLicense.License.BOMRef
+		} else {
+			license = common.HashLicense(compLicense.License.Name)
+		}
+	} else {
+		license = compLicense.License.ID
+	}
+	return license
 }
 
 func ParseCycloneDXBOM(doc *processor.Document) (*cdx.BOM, error) {
@@ -254,29 +348,16 @@ func (c *cyclonedxParser) GetPredicates(ctx context.Context) *assembler.IngestPr
 	// TODO: This is not based on the relationship so that can be inaccurate (can capture both direct and in-direct)...Remove this and be done below by the *c.cdxBom.Dependencies?
 	// see https://github.com/CycloneDX/specification/issues/33
 	if len(topLevelArts) > 0 || len(topLevelPkgs) > 0 {
-		var timestamp time.Time
-		var err error
-		if c.cdxBom.Metadata.Timestamp == "" {
-			// set the time to zero time if timestamp is not provided
-			timestamp = zeroTime
-		} else {
-			timestamp, err = time.Parse(time.RFC3339, c.cdxBom.Metadata.Timestamp)
-			if err != nil {
-				logger.Errorf("SPDX document had invalid created time %q : %v", c.cdxBom.Metadata.Timestamp, err)
-				return nil
-			}
-		}
-
 		if c.cdxBom.Dependencies == nil {
 			preds.IsDependency = append(preds.IsDependency, common.CreateTopLevelIsDeps(topLevelPkgs[0], c.packagePackages, nil, "top-level package GUAC heuristic connecting to each file/package")...)
 		}
 
 		if len(topLevelArts) > 0 {
 			for _, topLevelArt := range topLevelArts {
-				preds.HasSBOM = append(preds.HasSBOM, common.CreateTopLevelHasSBOMFromArtifact(topLevelArt, c.doc, c.cdxBom.SerialNumber, timestamp))
+				preds.HasSBOM = append(preds.HasSBOM, common.CreateTopLevelHasSBOMFromArtifact(topLevelArt, c.doc, c.cdxBom.SerialNumber, c.timestamp))
 			}
 		} else {
-			preds.HasSBOM = append(preds.HasSBOM, common.CreateTopLevelHasSBOMFromPkg(topLevelPkgs[0], c.doc, c.cdxBom.SerialNumber, timestamp))
+			preds.HasSBOM = append(preds.HasSBOM, common.CreateTopLevelHasSBOMFromPkg(topLevelPkgs[0], c.doc, c.cdxBom.SerialNumber, c.timestamp))
 		}
 	}
 
@@ -299,6 +380,23 @@ func (c *cyclonedxParser) GetPredicates(ctx context.Context) *assembler.IngestPr
 	preds.CertifyVuln = c.vulnData.certifyVuln
 	if c.cdxBom.Dependencies == nil {
 		return preds
+	}
+
+	// license information
+	for id, cls := range c.packageLegals {
+		for _, cl := range cls {
+			dec := common.ParseLicenses(cl.DeclaredLicense, nil, c.licenseInLine)
+			dis := common.ParseLicenses(cl.DiscoveredLicense, nil, c.licenseInLine)
+			for _, pkg := range c.packagePackages[id] {
+				cli := assembler.CertifyLegalIngest{
+					Pkg:          pkg,
+					Declared:     dec,
+					Discovered:   dis,
+					CertifyLegal: cl,
+				}
+				preds.CertifyLegal = append(preds.CertifyLegal, cli)
+			}
+		}
 	}
 
 	var directDependencies, indirectDependencies []string

--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx.go
@@ -215,10 +215,6 @@ func traverseComponents(c cyclonedxParser, components *[]cdx.Component) error {
 				} else {
 					purl = asmhelpers.GuacPkgPurl(comp.Name, &comp.Version)
 				}
-				err = traverseComponents(c, comp.Components)
-				if err != nil {
-					return err
-				}
 			}
 			pkg, err := asmhelpers.PurlToPkg(purl)
 			if err != nil {
@@ -240,6 +236,10 @@ func traverseComponents(c cyclonedxParser, components *[]cdx.Component) error {
 			// get other component packages
 			if err := c.getLicenseInformation(comp); err != nil {
 				return fmt.Errorf("failed to get license information for component package with error: %w", err)
+			}
+
+			if err := traverseComponents(c, comp.Components); err != nil {
+				return err
 			}
 		}
 	}
@@ -305,6 +305,7 @@ func getLicenseFromName(c *cyclonedxParser, compLicense cdx.LicenseChoice) strin
 			license = compLicense.License.BOMRef
 		} else {
 			license = common.HashLicense(compLicense.License.Name)
+			c.licenseInLine[license] = compLicense.License.Name
 		}
 	} else {
 		license = compLicense.License.ID

--- a/pkg/ingestor/parser/cyclonedx/parser_cyclonedx_test.go
+++ b/pkg/ingestor/parser/cyclonedx/parser_cyclonedx_test.go
@@ -127,6 +127,15 @@ func Test_cyclonedxParser(t *testing.T) {
 		},
 		wantPredicates: noAnalysisVexPredicates(),
 		wantErr:        false,
+	}, {
+		name: "valid CycloneDX VEX document with license information",
+		doc: &processor.Document{
+			Blob:   testdata.CycloneDXLegalExample,
+			Format: processor.FormatJSON,
+			Type:   processor.DocumentCycloneDX,
+		},
+		wantPredicates: &testdata.CdxQuarkusLegalPredicates,
+		wantErr:        false,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/ingestor/parser/spdx/parse_spdx.go
+++ b/pkg/ingestor/parser/spdx/parse_spdx.go
@@ -356,8 +356,8 @@ func (s *spdxParser) GetPredicates(ctx context.Context) *assembler.IngestPredica
 	}
 	for id, cls := range s.packageLegals {
 		for _, cl := range cls {
-			dec := common.ParseLicenses(cl.DeclaredLicense, lv)
-			dis := common.ParseLicenses(cl.DiscoveredLicense, lv)
+			dec := common.ParseLicenses(cl.DeclaredLicense, &lv, nil)
+			dis := common.ParseLicenses(cl.DiscoveredLicense, &lv, nil)
 			for i := range dec {
 				o, n := fixLicense(ctx, &dec[i], s.spdxDoc.OtherLicenses)
 				if o != "" {

--- a/pkg/ingestor/parser/spdx/parse_spdx.go
+++ b/pkg/ingestor/parser/spdx/parse_spdx.go
@@ -126,27 +126,29 @@ func (s *spdxParser) getTopLevelSPDXIDs() ([]string, error) {
 func (s *spdxParser) getPackages(topLevelSPDXIDs []string) error {
 	for _, pac := range s.spdxDoc.Packages {
 		// for each package create a package for each of them
-		purl := ""
+		purls := make([]string, 0)
 		for _, ext := range pac.PackageExternalReferences {
 			if ext.RefType == spdx_common.TypePackageManagerPURL {
-				purl = ext.Locator
+				purls = append(purls, ext.Locator)
 			}
 		}
-		if purl == "" {
-			purl = asmhelpers.GuacPkgPurl(pac.PackageName, &pac.PackageVersion)
+		if len(purls) == 0 {
+			purls = append(purls, asmhelpers.GuacPkgPurl(pac.PackageName, &pac.PackageVersion))
 		}
 
-		s.identifierStrings.PurlStrings = append(s.identifierStrings.PurlStrings, purl)
+		s.identifierStrings.PurlStrings = append(s.identifierStrings.PurlStrings, purls...)
 
-		pkg, err := asmhelpers.PurlToPkg(purl)
-		if err != nil {
-			return err
-		}
+		for _, purl := range purls {
+			pkg, err := asmhelpers.PurlToPkg(purl)
+			if err != nil {
+				return err
+			}
 
-		if slices.Contains(topLevelSPDXIDs, string(pac.PackageSPDXIdentifier)) {
-			s.topLevelPackages = append(s.topLevelPackages, pkg)
+			if slices.Contains(topLevelSPDXIDs, string(pac.PackageSPDXIdentifier)) {
+				s.topLevelPackages = append(s.topLevelPackages, pkg)
+			}
+			s.packagePackages[string(pac.PackageSPDXIdentifier)] = append(s.packagePackages[string(pac.PackageSPDXIdentifier)], pkg)
 		}
-		s.packagePackages[string(pac.PackageSPDXIdentifier)] = append(s.packagePackages[string(pac.PackageSPDXIdentifier)], pkg)
 
 		// if checksums exists create an artifact for each of them
 		for _, checksum := range pac.PackageChecksums {

--- a/pkg/ingestor/parser/spdx/parse_spdx_test.go
+++ b/pkg/ingestor/parser/spdx/parse_spdx_test.go
@@ -1453,6 +1453,125 @@ func Test_spdxParser(t *testing.T) {
 			wantErr:     false,
 			wantWarning: "Top-level unique artifact count (1) and top-level package count (2) are mismatched. SBOM ingestion may not be as expected.",
 		},
+		{
+			name: "SPDX with multiple referenceType=purl for a single package",
+			additionalOpts: []cmp.Option{
+				cmpopts.IgnoreFields(assembler.HasSBOMIngest{},
+					"HasSBOM"),
+			},
+			doc: &processor.Document{
+				Blob: []byte(`
+			{
+			"spdxVersion": "SPDX-2.3",
+			"SPDXID":"SPDXRef-DOCUMENT",
+			"name":"openssl-3.0.7-18.el9_2",
+			"creationInfo": { "created": "2023-01-01T01:01:01.00Z" },
+			"packages":[
+				{
+					"SPDXID":"SPDXRef-SRPM",
+					"name":"openssl",
+					"versionInfo": "3.0.7-18.el9_2",
+					"packageFileName": "openssl-3.0.7-18.el9_2.src.rpm",
+					"externalRefs":[
+						{
+							"referenceCategory":"PACKAGE_MANAGER",
+							"referenceLocator":"pkg:rpm/redhat/openssl@3.0.7-18.el9_2?repository_id=rhel-9-baseos-eus",
+							"referenceType":"purl"
+						},
+						{
+							"referenceCategory":"PACKAGE_MANAGER",
+							"referenceLocator":"pkg:rpm/redhat/openssl@3.0.7-18.el9_2?repository_id=rhel-9-baseos-tus",
+							"referenceType":"purl"
+						}
+					]
+				}
+			],
+			"relationships":[
+				{
+					"spdxElementId":"SPDXRef-DOCUMENT",
+					"relationshipType":"PACKAGE_OF",
+					"relatedSpdxElement":"SPDXRef-SRPM"
+				}
+			]
+			}
+			`),
+				Format: processor.FormatJSON,
+				Type:   processor.DocumentSPDX,
+				SourceInformation: processor.SourceInformation{
+					Collector: "TestCollector",
+					Source:    "TestSource",
+				},
+			},
+			wantPredicates: &assembler.IngestPredicates{
+				IsDependency: []assembler.IsDependencyIngest{
+					{
+						Pkg: &generated.PkgInputSpec{
+							Type:      "guac",
+							Namespace: &packageOfns,
+							Name:      "openssl-3.0.7-18.el9_2",
+							Version:   &packageOfEmptyString,
+							Subpath:   &packageOfEmptyString,
+						},
+						DepPkg: &generated.PkgInputSpec{
+							Type:      "rpm",
+							Namespace: ptrfrom.String("redhat"),
+							Name:      "openssl",
+							Version:   ptrfrom.String("3.0.7-18.el9_2"),
+							Qualifiers: []generated.PackageQualifierInputSpec{
+								{Key: "repository_id", Value: "rhel-9-baseos-eus"},
+							},
+							Subpath: &packageOfEmptyString,
+						},
+						IsDependency: &generated.IsDependencyInputSpec{
+							DependencyType: "UNKNOWN",
+							Justification:  "top-level package GUAC heuristic connecting to each file/package",
+						},
+					},
+					{
+						Pkg: &generated.PkgInputSpec{
+							Type:      "guac",
+							Namespace: &packageOfns,
+							Name:      "openssl-3.0.7-18.el9_2",
+							Version:   &packageOfEmptyString,
+							Subpath:   &packageOfEmptyString,
+						},
+						DepPkg: &generated.PkgInputSpec{
+							Type:      "rpm",
+							Namespace: ptrfrom.String("redhat"),
+							Name:      "openssl",
+							Version:   ptrfrom.String("3.0.7-18.el9_2"),
+							Qualifiers: []generated.PackageQualifierInputSpec{
+								{Key: "repository_id", Value: "rhel-9-baseos-tus"},
+							},
+							Subpath: &packageOfEmptyString,
+						},
+						IsDependency: &generated.IsDependencyInputSpec{
+							DependencyType: "UNKNOWN",
+							Justification:  "top-level package GUAC heuristic connecting to each file/package",
+						},
+					},
+				},
+
+				HasSBOM: []assembler.HasSBOMIngest{
+					{
+						Pkg: &generated.PkgInputSpec{
+							Type:      "guac",
+							Namespace: &packageOfns,
+							Name:      "openssl-3.0.7-18.el9_2",
+							Version:   &packageOfEmptyString,
+							Subpath:   &packageOfEmptyString,
+						},
+						HasSBOM: &generated.HasSBOMInputSpec{
+							Uri:              "https://anchore.com/syft/image/alpine-latest-e78eca08-d9f4-49c7-97e0-6d4b9bfa99c2",
+							Algorithm:        "sha256",
+							Digest:           "ba096464061993bbbdfc30a26b42cd8beb1bfff301726fe6c58cb45d468c7648",
+							DownloadLocation: "TestSource",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/ingestor/parser/spdx/parse_spdx_test.go
+++ b/pkg/ingestor/parser/spdx/parse_spdx_test.go
@@ -1522,7 +1522,9 @@ func Test_spdxParser(t *testing.T) {
 							},
 							Subpath: &packageOfEmptyString,
 						},
+						DepPkgMatchFlag: generated.MatchFlags{Pkg: generated.PkgMatchTypeSpecificVersion},
 						IsDependency: &generated.IsDependencyInputSpec{
+							VersionRange:   "3.0.7-18.el9_2",
 							DependencyType: "UNKNOWN",
 							Justification:  "top-level package GUAC heuristic connecting to each file/package",
 						},
@@ -1545,7 +1547,9 @@ func Test_spdxParser(t *testing.T) {
 							},
 							Subpath: &packageOfEmptyString,
 						},
+						DepPkgMatchFlag: generated.MatchFlags{Pkg: generated.PkgMatchTypeSpecificVersion},
 						IsDependency: &generated.IsDependencyInputSpec{
+							VersionRange:   "3.0.7-18.el9_2",
 							DependencyType: "UNKNOWN",
 							Justification:  "top-level package GUAC heuristic connecting to each file/package",
 						},


### PR DESCRIPTION
# Description of the PR

https://issues.redhat.com/browse/TC-1757

Backport

- https://github.com/guacsec/guac/pull/2101
- https://github.com/guacsec/guac/pull/1985

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
