### PR TITLE
TC-1947 Install nc for the podman kube_play tcp probes

### DIFF
--- a/dockerfiles/Dockerfile.guac-ubi
+++ b/dockerfiles/Dockerfile.guac-ubi
@@ -19,6 +19,6 @@ LABEL io.openshift.tags ="Trustification-Guac"
 LABEL name ="Trustification-Guac"
 LABEL summary ="Trustification-Guac"
 
-RUN microdnf install -y tar gzip
+RUN microdnf install -y tar gzip nc
 WORKDIR /root
 COPY --from=builder /go/src/github.com/guacsec/guac/bin/ /opt/guac/


### PR DESCRIPTION
# Description of the PR
Podman kube play use nc for the tcpProbes
https://github.com/containers/podman/blob/v4.5.0/pkg/specgen/generate/kube/kube.go#L596

and is not provide by the ubi image 



<!-- Please include a summary of the change, including relevant motivation and context. -->
Install nc on the guac image

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->
https://issues.redhat.com/browse/TC-1947

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged

nc is available and the probe works as expected without continuos restart
![guacnc](https://github.com/user-attachments/assets/f49806a6-0889-4b49-8c41-ed51e71ef95f)
