### PR TITLE
TC-1970 Add indexes supporting search.findVulnerabilities method

### DIFF
--- a/pkg/assembler/backends/ent/migrate/schema.go
+++ b/pkg/assembler/backends/ent/migrate/schema.go
@@ -336,6 +336,11 @@ var (
 					Where: "package_id IS NULL",
 				},
 			},
+			{
+				Name:    "certifyvex_package_id_status",
+				Unique:  false,
+				Columns: []*schema.Column{CertifyVexesColumns[9], CertifyVexesColumns[2]},
+			},
 		},
 	}
 	// CertifyVulnsColumns holds the columns for the "certify_vulns" table.
@@ -376,6 +381,11 @@ var (
 				Name:    "certifyvuln_db_uri_db_version_scanner_uri_scanner_version_origin_collector_time_scanned_document_ref_vulnerability_id_package_id",
 				Unique:  true,
 				Columns: []*schema.Column{CertifyVulnsColumns[2], CertifyVulnsColumns[3], CertifyVulnsColumns[4], CertifyVulnsColumns[5], CertifyVulnsColumns[6], CertifyVulnsColumns[7], CertifyVulnsColumns[1], CertifyVulnsColumns[8], CertifyVulnsColumns[9], CertifyVulnsColumns[10]},
+			},
+			{
+				Name:    "certifyvuln_package_id_vulnerability_id",
+				Unique:  false,
+				Columns: []*schema.Column{CertifyVulnsColumns[10], CertifyVulnsColumns[9]},
 			},
 		},
 	}

--- a/pkg/assembler/backends/ent/schema/certifyvex.go
+++ b/pkg/assembler/backends/ent/schema/certifyvex.go
@@ -65,6 +65,8 @@ func (CertifyVex) Indexes() []ent.Index {
 		index.Fields("known_since", "justification", "status", "statement", "status_notes", "origin", "collector", "document_ref").
 			Edges("vulnerability", "package").Unique().Annotations(entsql.IndexWhere("artifact_id IS NULL")).StorageKey("vex_artifact_id"),
 		index.Fields("known_since", "justification", "status", "statement", "status_notes", "origin", "collector", "document_ref").
-		Edges("vulnerability", "artifact").Unique().Annotations(entsql.IndexWhere("package_id IS NULL")).StorageKey("vex_package_id"),
+			Edges("vulnerability", "artifact").Unique().Annotations(entsql.IndexWhere("package_id IS NULL")).StorageKey("vex_package_id"),
+		// supporting search.findVulnerabilities method
+		index.Fields("package_id", "status"),
 	}
 }

--- a/pkg/assembler/backends/ent/schema/certifyvuln.go
+++ b/pkg/assembler/backends/ent/schema/certifyvuln.go
@@ -60,5 +60,7 @@ func (CertifyVuln) Edges() []ent.Edge {
 func (CertifyVuln) Indexes() []ent.Index {
 	return []ent.Index{
 		index.Fields("db_uri", "db_version", "scanner_uri", "scanner_version", "origin", "collector", "time_scanned", "document_ref").Edges("vulnerability", "package").Unique(),
+		// supporting search.findVulnerabilities method
+		index.Fields("package_id").Edges("vulnerability"),
 	}
 }


### PR DESCRIPTION
# Description of the PR

https://issues.redhat.com/browse/TC-1970

Changes:

- defined two indexes, one for `CertifiyVex` and the other for `CertifyVuln`, to support the queries for the `search.findVulnerabilities` method
- optimized queries to just retrieve IDs rather than all the data, hence simplifying also the following UUIDs management
- removed an unnecessary ordering since it's then up to the UI to sort data in the browser

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
