### PR TITLE
TC-2026 Enforce 'guacPkgId' when namespace is nil

### DIFF
--- a/internal/testing/backend/pkg_test.go
+++ b/internal/testing/backend/pkg_test.go
@@ -115,6 +115,57 @@ func TestPackages(t *testing.T) {
 		idInFilter: false,
 		want:       []*model.Package{testdata.P5out},
 		wantErr:    false,
+	}, {
+		// https://issues.redhat.com/browse/TC-2026
+		name: "TC-2026 [1/2] package without namespace",
+		pkgInput: &model.PkgInputSpec{
+			Type:    "maven",
+			Name:    "jenkins-core",
+			Version: ptrfrom.String("1.498"),
+		},
+		pkgFilter: &model.PkgSpec{
+			Name:    ptrfrom.String("jenkins-core"),
+			Version: ptrfrom.String("1.498"),
+		},
+		idInFilter: false,
+		want: []*model.Package{{
+			Type: "maven",
+			Namespaces: []*model.PackageNamespace{{
+				Names: []*model.PackageName{{
+					Name: "jenkins-core",
+					Versions: []*model.PackageVersion{{
+						Version: "1.498",
+					}},
+				}},
+			}},
+		}},
+		wantErr: false,
+	}, {
+		// https://issues.redhat.com/browse/TC-2026
+		name: "TC-2026 [2/2] package with empty namespace",
+		pkgInput: &model.PkgInputSpec{
+			Type:      "maven",
+			Namespace: ptrfrom.String(""),
+			Name:      "jenkins-core",
+			Version:   ptrfrom.String("1.498"),
+		},
+		pkgFilter: &model.PkgSpec{
+			Name:    ptrfrom.String("jenkins-core"),
+			Version: ptrfrom.String("1.498"),
+		},
+		idInFilter: false,
+		want: []*model.Package{{
+			Type: "maven",
+			Namespaces: []*model.PackageNamespace{{
+				Names: []*model.PackageName{{
+					Name: "jenkins-core",
+					Versions: []*model.PackageVersion{{
+						Version: "1.498",
+					}},
+				}},
+			}},
+		}},
+		wantErr: false,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/assembler/backends/ent/backend/package.go
+++ b/pkg/assembler/backends/ent/backend/package.go
@@ -277,7 +277,7 @@ func upsertPackage(ctx context.Context, tx *ent.Tx, pkg model.IDorPkgInput) (*mo
 		Exec(ctx)
 	if err != nil {
 		if err != stdsql.ErrNoRows {
-			return nil, errors.Wrap(err, "upsert package name")
+			return nil, errors.Wrap(err, fmt.Sprintf("upsert package name %+v (%v)", pkg.PackageInput, pkgNameID))
 		}
 	}
 
@@ -293,7 +293,7 @@ func upsertPackage(ctx context.Context, tx *ent.Tx, pkg model.IDorPkgInput) (*mo
 		DoNothing().
 		Exec(ctx); err != nil {
 		if err != stdsql.ErrNoRows {
-			return nil, errors.Wrap(err, "upsert package version")
+			return nil, errors.Wrap(err, fmt.Sprintf("upsert package version %+v (%v->%v)", pkg.PackageInput, pkgVersionID, pkgNameID))
 		}
 	}
 

--- a/pkg/assembler/helpers/package.go
+++ b/pkg/assembler/helpers/package.go
@@ -72,21 +72,17 @@ func guacPkgId(pkgType string, namespace *string, name string, pkgVersion *strin
 	ids.NameId = fmt.Sprintf("%s::%s", ids.NamespaceId, name)
 
 	var version string
-	if pkgVersion != nil {
-		if *pkgVersion != "" {
-			version = *pkgVersion
-		} else {
-			version = guacEmpty
-		}
+	if pkgVersion != nil && *pkgVersion != "" {
+		version = *pkgVersion
+	} else {
+		version = guacEmpty
 	}
 
 	var subpath string
-	if pkgSubpath != nil {
-		if *pkgSubpath != "" {
-			subpath = *pkgSubpath
-		} else {
-			subpath = guacEmpty
-		}
+	if pkgSubpath != nil && *pkgSubpath != "" {
+		subpath = *pkgSubpath
+	} else {
+		subpath = guacEmpty
 	}
 
 	ids.VersionId = fmt.Sprintf("%s::%s::%s?", ids.NameId, version, subpath)

--- a/pkg/assembler/helpers/package.go
+++ b/pkg/assembler/helpers/package.go
@@ -60,12 +60,13 @@ func guacPkgId(pkgType string, namespace *string, name string, pkgVersion *strin
 	ids.TypeId = pkgType
 
 	var ns string
-	if namespace != nil {
-		if *namespace != "" {
-			ns = *namespace
-		} else {
-			ns = guacEmpty
-		}
+	// https://issues.redhat.com/browse/TC-2026 it turned out that guac-rs sends PkgInputSpec to ingestPackage/s
+	// w/o the namespace field instead of providing it with the default "" value. This created an inconsistency when
+	// the same PURL was ingested through 'guacone collect', i.e. bombastic-collector, or guac-rs, i.e. collector-osv,
+	if namespace != nil && *namespace != "" {
+		ns = *namespace
+	} else {
+		ns = guacEmpty
 	}
 	ids.NamespaceId = fmt.Sprintf("%s::%s", ids.TypeId, ns)
 	ids.NameId = fmt.Sprintf("%s::%s", ids.NamespaceId, name)

--- a/pkg/assembler/helpers/package_test.go
+++ b/pkg/assembler/helpers/package_test.go
@@ -69,6 +69,39 @@ func Test_guacPkgId(t *testing.T) {
 			NameId:      "maven::org.apache.xmlgraphics::batik-anim",
 			VersionId:   "maven::org.apache.xmlgraphics::batik-anim::1.9.1::guac-empty-@@?classifier=dist&type=zip&",
 		},
+	}, {
+		// https://issues.redhat.com/browse/TC-2026
+		name: "TC-2026 [1/2] pkg with empty namespace",
+		pkgServer: &model.PkgInputSpec{
+			Type:       "maven",
+			Namespace:  ptrfrom.String(""),
+			Name:       "batik-anim",
+			Version:    ptrfrom.String("1.9.1"),
+			Subpath:    ptrfrom.String(""),
+			Qualifiers: serverQualifiers,
+		},
+		want: PkgIds{
+			TypeId:      "maven",
+			NamespaceId: "maven::guac-empty-@@",
+			NameId:      "maven::guac-empty-@@::batik-anim",
+			VersionId:   "maven::guac-empty-@@::batik-anim::1.9.1::guac-empty-@@?classifier=dist&type=zip&",
+		},
+	}, {
+		// https://issues.redhat.com/browse/TC-2026
+		name: "TC-2026 [2/2] pkg without namespace",
+		pkgServer: &model.PkgInputSpec{
+			Type:       "maven",
+			Name:       "batik-anim",
+			Version:    ptrfrom.String("1.9.1"),
+			Subpath:    ptrfrom.String(""),
+			Qualifiers: serverQualifiers,
+		},
+		want: PkgIds{
+			TypeId:      "maven",
+			NamespaceId: "maven::guac-empty-@@",
+			NameId:      "maven::guac-empty-@@::batik-anim",
+			VersionId:   "maven::guac-empty-@@::batik-anim::1.9.1::guac-empty-@@?classifier=dist&type=zip&",
+		},
 	},
 	}
 	for _, tt := range tests {

--- a/pkg/assembler/helpers/package_test.go
+++ b/pkg/assembler/helpers/package_test.go
@@ -102,6 +102,72 @@ func Test_guacPkgId(t *testing.T) {
 			NameId:      "maven::guac-empty-@@::batik-anim",
 			VersionId:   "maven::guac-empty-@@::batik-anim::1.9.1::guac-empty-@@?classifier=dist&type=zip&",
 		},
+	}, {
+		// https://issues.redhat.com/browse/TC-2026
+		name: "TC-2026 [1/2] pkg with empty version",
+		pkgServer: &model.PkgInputSpec{
+			Type:       "maven",
+			Namespace:  ptrfrom.String("org.apache.xmlgraphics"),
+			Name:       "batik-anim",
+			Version:    ptrfrom.String(""),
+			Subpath:    ptrfrom.String(""),
+			Qualifiers: serverQualifiers,
+		},
+		want: PkgIds{
+			TypeId:      "maven",
+			NamespaceId: "maven::org.apache.xmlgraphics",
+			NameId:      "maven::org.apache.xmlgraphics::batik-anim",
+			VersionId:   "maven::org.apache.xmlgraphics::batik-anim::guac-empty-@@::guac-empty-@@?classifier=dist&type=zip&",
+		},
+	}, {
+		// https://issues.redhat.com/browse/TC-2026
+		name: "TC-2026 [2/2] pkg without version",
+		pkgServer: &model.PkgInputSpec{
+			Type:       "maven",
+			Namespace:  ptrfrom.String("org.apache.xmlgraphics"),
+			Name:       "batik-anim",
+			Subpath:    ptrfrom.String(""),
+			Qualifiers: serverQualifiers,
+		},
+		want: PkgIds{
+			TypeId:      "maven",
+			NamespaceId: "maven::org.apache.xmlgraphics",
+			NameId:      "maven::org.apache.xmlgraphics::batik-anim",
+			VersionId:   "maven::org.apache.xmlgraphics::batik-anim::guac-empty-@@::guac-empty-@@?classifier=dist&type=zip&",
+		},
+	}, {
+		// https://issues.redhat.com/browse/TC-2026
+		name: "TC-2026 [1/2] pkg with empty subpath",
+		pkgServer: &model.PkgInputSpec{
+			Type:       "maven",
+			Namespace:  ptrfrom.String("org.apache.xmlgraphics"),
+			Name:       "batik-anim",
+			Version:    ptrfrom.String("1.9.1"),
+			Subpath:    ptrfrom.String(""),
+			Qualifiers: serverQualifiers,
+		},
+		want: PkgIds{
+			TypeId:      "maven",
+			NamespaceId: "maven::org.apache.xmlgraphics",
+			NameId:      "maven::org.apache.xmlgraphics::batik-anim",
+			VersionId:   "maven::org.apache.xmlgraphics::batik-anim::1.9.1::guac-empty-@@?classifier=dist&type=zip&",
+		},
+	}, {
+		// https://issues.redhat.com/browse/TC-2026
+		name: "TC-2026 [2/2] pkg without subpath",
+		pkgServer: &model.PkgInputSpec{
+			Type:       "maven",
+			Namespace:  ptrfrom.String("org.apache.xmlgraphics"),
+			Name:       "batik-anim",
+			Version:    ptrfrom.String("1.9.1"),
+			Qualifiers: serverQualifiers,
+		},
+		want: PkgIds{
+			TypeId:      "maven",
+			NamespaceId: "maven::org.apache.xmlgraphics",
+			NameId:      "maven::org.apache.xmlgraphics::batik-anim",
+			VersionId:   "maven::org.apache.xmlgraphics::batik-anim::1.9.1::guac-empty-@@?classifier=dist&type=zip&",
+		},
 	},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
# Description of the PR

https://issues.redhat.com/browse/TC-2026

Despite `namespace` in `PkgInputSpec` has `""` default value, `nil` can be sent from clients not adhering to the GraphQL schema and this causes TC-2026, i.e. ` ent: constraint failed: pq: insert or update on table "package_versions" violates foreign key constraint "package_versions_package_names_versions"`.

With this PR, Guac has a more stable approach that avoid this issue considering a `nil` namespace like an empty, i.e. `""`, namespace and so generating consistent `PkgIDs.NameId` values.
In fact the issue comes from having different `PkgIDs.NameId` values for the same type and package if the namespace was empty or nil and hence triggering the foreign key violation.

Both an integration test in `pkg_test.go` and a unit test in `package_test.go` have been added.
Also the error thrown in the ingestion has been enriched to better support analysis in case of similar issues in the future.

Same considerations and changes apply also for `version` and `subpath` fields.

## Issue details

1. Package `{packageInput: {type: "pypi", namespace:"", name: "tensorflow-cpu", version:"2.3.0"}}` is ingested
2. one row insert into `package_names` table with UUID x (generated from `PkgIDs.NameId` value, i.e. `pypi::guac-empty-@@::tensorflow-cpu`)
3. one row insert into `package_versions` using **x value for `NameID`** foreign key
4. Package `{packageInput: {type: "pypi", name: "tensorflow-cpu", version:"2.3.0"}}` is ingested (and it "represents" the same package ingested in step 1)
5. one row insert into `package_names` table with UUID y (generated from `PkgIDs.NameId` value, i.e. `pypi::::tensorflow-cpu`) BUT if conflicts with row inserted in step 2 so `do_nothing` is applied and no changes are applied to the previous row in the DB
6. one row insert into `package_versions` using **y value for `NameID`** foreign key and it fails because y value has never been inserted, i.e. foreign key violation

# PR Checklist

- [x] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [x] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
