### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for guac

### DIFF
--- a/dockerfiles/Dockerfile.guac-ubi
+++ b/dockerfiles/Dockerfile.guac-ubi
@@ -16,7 +16,8 @@ LABEL description="Trustification-Guac"
 LABEL io.k8s.description ="Trustification-Guac"
 LABEL io.k8s.display-name ="Trustification-Guac"
 LABEL io.openshift.tags ="Trustification-Guac"
-LABEL name ="Trustification-Guac"
+LABEL name ="rhtpa/rhtpa-guac-rhel9"
+LABEL cpe ="cpe:/a:redhat:trusted_profile_analyzer:1.3::el9"
 LABEL summary ="Trustification-Guac"
 
 RUN microdnf install -y tar gzip


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
